### PR TITLE
8288101: False build warning-as-error with GCC 9 after JDK-8214976

### DIFF
--- a/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
+++ b/src/hotspot/share/utilities/compilerWarnings_gcc.hpp
@@ -69,9 +69,12 @@
 
 #endif // clang/gcc version check
 
-#if (__GNUC__ >= 9) || (defined(__clang_major__) && (__clang_major__ >= 14))
+#if (__GNUC__ >= 10) || (defined(__clang_major__) && (__clang_major__ >= 14))
 
 // Use "warning" attribute to detect uses of "forbidden" functions.
+//
+// Note: The warning attribute is available since GCC 9, but disabling pragmas
+// does not work reliably in ALLOW_C_FUNCTION. GCC 10+ and up work fine.
 //
 // Note: _FORTIFY_SOURCE transforms calls to certain functions into calls to
 // associated "checking" functions, and that transformation seems to occur
@@ -89,6 +92,6 @@
   __VA_ARGS__                                           \
   PRAGMA_DIAG_POP
 
-#endif // gcc9+ or clang14+
+#endif // gcc10+ or clang14+
 
 #endif // SHARE_UTILITIES_COMPILERWARNINGS_GCC_HPP


### PR DESCRIPTION
gcc version 9.4.0 (also 9.3.1) produces build warning after [JDK-8214976](https://bugs.openjdk.org/browse/JDK-8214976):

```
os_posix.cpp:786:34: error: call to 'exit' declared with attribute warning: use os::exit [-Werror=attribute-warning]
  786 | ALLOW_C_FUNCTION(::exit, ::exit(num);)
      | ~~~~~~^~~~~
```

Apparently, GCC 9 has a bug with nesting pragmas. The [Godbolt experiments](https://godbolt.org/z/vonsqEnK6) show this only affects GCC 9, and there are no easy way to restructure the macros to dodge this, so the way out to bump the requirement for new macros to GCC >= 10.

Additional testing:
 - [x] Linux x86_64 build with GCC 9.4.0 (now passes without warnings)
 - [x] Linux x86_64 build with GCC 10.2.1 (still passes)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288101](https://bugs.openjdk.org/browse/JDK-8288101): False build warning-as-error with GCC 9 after JDK-8214976


### Reviewers
 * [Martin Doerr](https://openjdk.java.net/census#mdoerr) (@TheRealMDoerr - **Reviewer**)
 * [Zhengyu Gu](https://openjdk.java.net/census#zgu) (@zhengyu123 - **Reviewer**)
 * [Kim Barrett](https://openjdk.java.net/census#kbarrett) (@kimbarrett - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/1/head:pull/1` \
`$ git checkout pull/1`

Update a local copy of the PR: \
`$ git checkout pull/1` \
`$ git pull https://git.openjdk.org/jdk19 pull/1/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 1`

View PR using the GUI difftool: \
`$ git pr show -t 1`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/1.diff">https://git.openjdk.org/jdk19/pull/1.diff</a>

</details>
