### PR TITLE
JDK-8281445: Document the default value for the override-methods option

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -629,7 +629,8 @@ doclet.usage.override-methods.parameters=\
     (detail|summary)
 
 doclet.usage.override-methods.description=\
-    Document overridden methods in the detail or summary sections
+    Document overridden methods in the detail or summary sections.\n\
+    The default is 'detail'.
 
 doclet.usage.allow-script-in-comments.description=\
     Allow JavaScript in options and comments


### PR DESCRIPTION
Please refer a trivial update for the javadoc command-line help, to specify the default value for the --override-methods option.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8281445](https://bugs.openjdk.org/browse/JDK-8281445): Document the default value for the override-methods option


### Reviewers
 * [Pavel Rappo](https://openjdk.java.net/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/2/head:pull/2` \
`$ git checkout pull/2`

Update a local copy of the PR: \
`$ git checkout pull/2` \
`$ git pull https://git.openjdk.org/jdk19 pull/2/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 2`

View PR using the GUI difftool: \
`$ git pr show -t 2`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/2.diff">https://git.openjdk.org/jdk19/pull/2.diff</a>

</details>
