### PR TITLE
8288105: [PPC64] Problems with -XX:+VerifyStack

### DIFF
--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -219,14 +219,6 @@ frame frame::sender_for_interpreter_frame(RegisterMap *map) const {
   return frame(sender_sp(), sender_pc(), (intptr_t*)get_ijava_state()->sender_sp);
 }
 
-intptr_t* frame::compiled_sender_sp(CodeBlob* cb) const {
-  return sender_sp();
-}
-
-address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
-  return sender_pc_addr();
-}
-
 void frame::patch_pc(Thread* thread, address pc) {
   assert(_cb == CodeCache::find_blob(pc), "unexpected pc");
   address* pc_addr = (address*)&(own_abi()->lr);

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -394,17 +394,7 @@ intptr_t *frame::initial_deoptimization_info() {
 
 #ifndef PRODUCT
 // This is a generic constructor which is only used by pns() in debug.cpp.
-frame::frame(void* sp, void* fp, void* pc) : _sp((intptr_t*)sp),
-                                             _pc((address)pc),
-                                             _cb(NULL),
-                                             _oop_map(NULL),
-                                             _on_heap(false),
-                                             DEBUG_ONLY(_frame_index(-1) COMMA)
-                                             _unextended_sp((intptr_t*)sp),
-                                             _fp(NULL) {
-  setup(); // also sets _fp and adjusts _unextended_sp
-}
-
+frame::frame(void* sp, void* fp, void* pc) : frame((intptr_t*)sp, (address)pc) {}
 #endif
 
 // Pointer beyond the "oldest/deepest" BasicObjectLock on stack.

--- a/src/hotspot/cpu/ppc/frame_ppc.cpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.cpp
@@ -394,6 +394,7 @@ intptr_t *frame::initial_deoptimization_info() {
 
 #ifndef PRODUCT
 // This is a generic constructor which is only used by pns() in debug.cpp.
+// fp is dropped and gets determined by backlink.
 frame::frame(void* sp, void* fp, void* pc) : frame((intptr_t*)sp, (address)pc) {}
 #endif
 

--- a/src/hotspot/cpu/ppc/frame_ppc.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.hpp
@@ -382,13 +382,9 @@
   const ImmutableOopMap* get_oop_map() const;
 
   // Constructors
-  inline frame(intptr_t* sp, address pc);
-  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
+  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp = nullptr, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
 
  private:
-
-  intptr_t* compiled_sender_sp(CodeBlob* cb) const;
-  address*  compiled_sender_pc_addr(CodeBlob* cb) const;
   address*  sender_pc_addr(void) const;
 
  public:

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -312,6 +312,9 @@ inline frame frame::sender_raw(RegisterMap* map) const {
 inline frame frame::sender_for_compiled_frame(RegisterMap *map) const {
   assert(map != nullptr, "map must be set");
 
+  intptr_t* sender_sp = this->sender_sp();
+  address   sender_pc = this->sender_pc();
+
   // Now adjust the map.
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
@@ -321,7 +324,7 @@ inline frame frame::sender_for_compiled_frame(RegisterMap *map) const {
     }
   }
 
-  return frame(sender_sp(), sender_pc());
+  return frame(sender_sp, sender_pc);
 }
 
 template <typename RegisterMapT>

--- a/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
+++ b/src/hotspot/cpu/ppc/frame_ppc.inline.hpp
@@ -33,9 +33,12 @@
 
 // Inline functions for ppc64 frames:
 
-// Initialize frame members (_pc and _sp must be given)
+// Initialize frame members (_sp must be given)
 inline void frame::setup() {
-  assert(_pc != nullptr, "precondition: must have PC");
+  if (_pc == nullptr) {
+    _pc = (address)own_abi()->lr;
+    assert(_pc != nullptr, "must have PC");
+  }
 
   if (_cb == nullptr) {
     _cb = CodeCache::find_blob(_pc);
@@ -43,6 +46,10 @@ inline void frame::setup() {
 
   if (_fp == nullptr) {
     _fp = (intptr_t*)own_abi()->callers_sp;
+  }
+
+  if (_unextended_sp == nullptr) {
+    _unextended_sp = _sp;
   }
 
   // When thawing continuation frames the _unextended_sp passed to the constructor is not aligend
@@ -68,27 +75,17 @@ inline void frame::setup() {
 
 // Constructors
 
-// Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
+// Initialize all fields
 inline frame::frame() : _sp(nullptr), _pc(nullptr), _cb(nullptr), _oop_map(nullptr), _deopt_state(unknown),
                         _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(nullptr), _fp(nullptr) {}
 
-inline frame::frame(intptr_t* sp)
-  : _sp(sp), _pc((address)own_abi()->lr), _cb(nullptr), _oop_map(nullptr),
-    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
-  setup();
-}
-
-inline frame::frame(intptr_t* sp, address pc)
-  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
-    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
-  setup();
-}
-
 inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp, CodeBlob* cb)
-  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+  : _sp(sp), _pc(pc), _cb(cb), _oop_map(nullptr),
     _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(unextended_sp), _fp(fp) {
   setup();
 }
+
+inline frame::frame(intptr_t* sp) : frame(sp, nullptr) {}
 
 // Accessors
 
@@ -305,7 +302,7 @@ inline frame frame::sender_raw(RegisterMap* map) const {
   if (is_interpreted_frame()) return sender_for_interpreter_frame(map);
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
 
-  if (_cb != NULL) return sender_for_compiled_frame(map);
+  if (_cb != nullptr) return sender_for_compiled_frame(map);
 
   // Must be native-compiled frame, i.e. the marshaling code for native
   // methods that exists in the core system.
@@ -313,24 +310,18 @@ inline frame frame::sender_raw(RegisterMap* map) const {
 }
 
 inline frame frame::sender_for_compiled_frame(RegisterMap *map) const {
-  assert(map != NULL, "map must be set");
-
-  // Frame owned by compiler.
-  address pc = *compiled_sender_pc_addr(_cb);
-  frame caller(compiled_sender_sp(_cb), pc);
+  assert(map != nullptr, "map must be set");
 
   // Now adjust the map.
-
-  // Get the rest.
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
     map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
+    if (_cb->oop_maps() != nullptr) {
       OopMapSet::update_register_map(this, map);
     }
   }
 
-  return caller;
+  return frame(sender_sp(), sender_pc());
 }
 
 template <typename RegisterMapT>

--- a/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
+++ b/src/hotspot/cpu/ppc/sharedRuntime_ppc.cpp
@@ -2591,7 +2591,6 @@ void SharedRuntime::generate_deopt_blob() {
   // --------------------------------------------------------------------------
   __ BIND(exec_mode_initialized);
 
-  {
   const Register unroll_block_reg = R22_tmp2;
 
   // We need to set `last_Java_frame' because `fetch_unroll_info' will
@@ -2648,7 +2647,6 @@ void SharedRuntime::generate_deopt_blob() {
 
   // stack: (skeletal interpreter frame, ..., optional skeletal
   // interpreter frame, optional c2i, caller of deoptee, ...).
-  }
 
   // push an `unpack_frame' taking care of float / int return values.
   __ push_frame(frame_size_in_bytes, R0/*tmp*/);
@@ -2663,7 +2661,7 @@ void SharedRuntime::generate_deopt_blob() {
 
   // Let the unpacker layout information in the skeletal frames just
   // allocated.
-  __ get_PC_trash_LR(R3_RET);
+  __ calculate_address_from_global_toc(R3_RET, calls_return_pc, true, true, true, true);
   __ set_last_Java_frame(/*sp*/R1_SP, /*pc*/R3_RET);
   // This is a call to a LEAF method, so no oop map is required.
   __ call_VM_leaf(CAST_FROM_FN_PTR(address, Deoptimization::unpack_frames),
@@ -2715,6 +2713,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   Register unroll_block_reg = R21_tmp1;
   Register klass_index_reg  = R22_tmp2;
   Register unc_trap_reg     = R23_tmp3;
+  Register r_return_pc      = R27_tmp7;
 
   OopMapSet* oop_maps = new OopMapSet();
   int frame_size_in_bytes = frame::abi_reg_args_size;
@@ -2739,9 +2738,9 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // sender frame as the deoptee frame.
   // Remember the offset of the instruction whose address will be
   // moved to R11_scratch1.
-  address gc_map_pc = __ get_PC_trash_LR(R11_scratch1);
-
-  __ set_last_Java_frame(/*sp*/R1_SP, /*pc*/R11_scratch1);
+  address gc_map_pc = __ pc();
+  __ calculate_address_from_global_toc(r_return_pc, gc_map_pc, true, true, true, true);
+  __ set_last_Java_frame(/*sp*/R1_SP, r_return_pc);
 
   __ mr(klass_index_reg, R3);
   __ li(R5_ARG3, Deoptimization::Unpack_uncommon_trap);
@@ -2797,8 +2796,7 @@ void SharedRuntime::generate_uncommon_trap_blob() {
   // ...).
 
   // Set the "unpack_frame" as last_Java_frame.
-  __ get_PC_trash_LR(R11_scratch1);
-  __ set_last_Java_frame(/*sp*/R1_SP, /*pc*/R11_scratch1);
+  __ set_last_Java_frame(/*sp*/R1_SP, r_return_pc);
 
   // Indicate it is the uncommon trap case.
   __ li(unc_trap_reg, Deoptimization::Unpack_uncommon_trap);


### PR DESCRIPTION
Deoptimization and uncommon trap stubs require last Java PC to point to a PC which has an appropriate OopMap. Otherwise, -XX:+VerifyStack does no longer work after [JDK-8284161](https://bugs.openjdk.org/browse/JDK-8284161).
I had to debug through the frame stuff and I made the code a bit more robust and easier to use and debug.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288105](https://bugs.openjdk.org/browse/JDK-8288105): [PPC64] Problems with -XX:+VerifyStack


### Reviewers
 * [Goetz Lindenmaier](https://openjdk.java.net/census#goetz) (@GoeLin - **Reviewer**) ⚠️ Review applies to [63dc3c61](https://git.openjdk.org/jdk19/pull/3/files/63dc3c61d707bcbfd89d7ea27cddc83d783b9c8a)
 * [Matthias Baesken](https://openjdk.java.net/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/3/head:pull/3` \
`$ git checkout pull/3`

Update a local copy of the PR: \
`$ git checkout pull/3` \
`$ git pull https://git.openjdk.org/jdk19 pull/3/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 3`

View PR using the GUI difftool: \
`$ git pr show -t 3`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/3.diff">https://git.openjdk.org/jdk19/pull/3.diff</a>

</details>
