### PR TITLE
8286176: Add JNI_VERSION_19 to jni.h and JNI spec

### DIFF
--- a/src/hotspot/share/prims/jni.cpp
+++ b/src/hotspot/share/prims/jni.cpp
@@ -99,7 +99,7 @@
 #include "jvmci/jvmciCompiler.hpp"
 #endif
 
-static jint CurrentVersion = JNI_VERSION_10;
+static jint CurrentVersion = JNI_VERSION_19;
 
 #if defined(_WIN32) && !defined(USE_VECTORED_EXCEPTION_HANDLING)
 extern LONG WINAPI topLevelExceptionFilter(_EXCEPTION_POINTERS* );

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3549,6 +3549,7 @@ jboolean Threads::is_supported_jni_version(jint version) {
   if (version == JNI_VERSION_1_8) return JNI_TRUE;
   if (version == JNI_VERSION_9) return JNI_TRUE;
   if (version == JNI_VERSION_10) return JNI_TRUE;
+  if (version == JNI_VERSION_19) return JNI_TRUE;
   return JNI_FALSE;
 }
 

--- a/src/java.base/share/native/include/jni.h
+++ b/src/java.base/share/native/include/jni.h
@@ -1990,6 +1990,7 @@ JNI_OnUnload(JavaVM *vm, void *reserved);
 #define JNI_VERSION_1_8 0x00010008
 #define JNI_VERSION_9   0x00090000
 #define JNI_VERSION_10  0x000a0000
+#define JNI_VERSION_19  0x00130000
 
 #ifdef __cplusplus
 } /* extern "C" */

--- a/src/jdk.management.agent/unix/native/libmanagement_agent/FileSystemImpl.c
+++ b/src/jdk.management.agent/unix/native/libmanagement_agent/FileSystemImpl.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2004, 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2004, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -45,7 +45,7 @@ JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
         return JNI_EVERSION; /* JNI version not supported */
     }
 
-    return JNI_VERSION_10;
+    return JNI_VERSION_19;
 }
 
 /*

--- a/src/jdk.management.agent/windows/native/libmanagement_agent/FileSystemImpl.c
+++ b/src/jdk.management.agent/windows/native/libmanagement_agent/FileSystemImpl.c
@@ -39,7 +39,7 @@ JNIEXPORT jint JNICALL DEF_JNI_OnLoad(JavaVM *vm, void *reserved)
         return JNI_EVERSION; /* JNI version not supported */
     }
 
-    return JNI_VERSION_10;
+    return JNI_VERSION_19;
 }
 
 

--- a/test/hotspot/jtreg/native_sanity/JniVersion.java
+++ b/test/hotspot/jtreg/native_sanity/JniVersion.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,12 +27,12 @@
  */
 public class JniVersion {
 
-    public static final int JNI_VERSION_10 = 0x000a0000;
+    public static final int JNI_VERSION_19 = 0x00130000;
 
     public static void main(String... args) throws Exception {
         System.loadLibrary("JniVersion");
         int res = getJniVersion();
-        if (res != JNI_VERSION_10) {
+        if (res != JNI_VERSION_19) {
             throw new Exception("Unexpected value returned from getJniVersion(): 0x" + Integer.toHexString(res));
         }
     }

--- a/test/jdk/java/lang/ClassLoader/nativeLibrary/libnativeLibraryTest.c
+++ b/test/jdk/java/lang/ClassLoader/nativeLibrary/libnativeLibraryTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 static jint count = 0;
 static jclass test_class;
-static jint current_jni_version = JNI_VERSION_10;
+static jint current_jni_version = JNI_VERSION_19;
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved) {

--- a/test/jdk/java/lang/StackWalker/libnativeMethod.c
+++ b/test/jdk/java/lang/StackWalker/libnativeMethod.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -28,7 +28,7 @@
 
 static jclass test_class;
 static jmethodID mid;
-static jint current_jni_version = JNI_VERSION_10;
+static jint current_jni_version = JNI_VERSION_19;
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved) {

--- a/test/jdk/jdk/internal/loader/NativeLibraries/libnativeLibrariesTest.c
+++ b/test/jdk/jdk/internal/loader/NativeLibraries/libnativeLibrariesTest.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2020, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -27,7 +27,7 @@
 #include "jni.h"
 
 static jclass test_class;
-static jint current_jni_version = JNI_VERSION_10;
+static jint current_jni_version = JNI_VERSION_19;
 
 JNIEXPORT jint JNICALL
 JNI_OnLoad(JavaVM *vm, void *reserved) {

--- a/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
+++ b/test/micro/org/openjdk/bench/java/lang/foreign/libQSortJNI.c
@@ -68,7 +68,7 @@ int java_cmp(const void *a, const void *b) {
    int v2 = *((int*)b);
 
    JNIEnv* env;
-   (*VM)->GetEnv(VM, (void**) &env, JNI_VERSION_10);
+   (*VM)->GetEnv(VM, (void**) &env, JNI_VERSION_19);
 
    jclass qsortClass = (*env)->FindClass(env, "org/openjdk/bench/java/lang/foreign/QSort");
    jmethodID methodId = (*env)->GetStaticMethodID(env, qsortClass, "jni_upcall_compar", "(II)I");


### PR DESCRIPTION
JNI is updated in Java 19 so we need to define JNI_VERSION_19 and change GetVersion to return this version.

test/hotspot/jtreg/native_sanity/JniVersion.java is updated to check that JNI_VERSION_19 is returned. The native library in the JMX agent, and several tests, define JNI_OnLoad that return JNI_VERSION_10 as the JNI version needed. These are updated to return JNI_VERSION_19 although these updates aren't strictly needed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8286176](https://bugs.openjdk.org/browse/JDK-8286176): Add JNI_VERSION_19 to jni.h and JNI spec
 * [JDK-8288283](https://bugs.openjdk.org/browse/JDK-8288283): Add JNI_VERSION_19 to jni.h and JNI spec (**CSR**)


### Reviewers
 * [Daniel D. Daugherty](https://openjdk.java.net/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [Iris Clark](https://openjdk.java.net/census#iris) (@irisclark - **Reviewer**)
 * [Mandy Chung](https://openjdk.java.net/census#mchung) (@mlchung - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/7/head:pull/7` \
`$ git checkout pull/7`

Update a local copy of the PR: \
`$ git checkout pull/7` \
`$ git pull https://git.openjdk.org/jdk19 pull/7/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 7`

View PR using the GUI difftool: \
`$ git pr show -t 7`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/7.diff">https://git.openjdk.org/jdk19/pull/7.diff</a>

</details>
