### PR TITLE
8288324: Loom: Uninitialized JvmtiEnvs in VM_Virtual* ops

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.hpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.hpp
@@ -661,7 +661,8 @@ public:
   VM_VirtualThreadGetStackTrace(JvmtiEnv *env, Handle vthread_h,
                                 jint start_depth, jint max_count,
                                 jvmtiFrameInfo* frame_buffer, jint* count_ptr)
-    : _vthread_h(vthread_h),
+    : _env(env),
+      _vthread_h(vthread_h),
       _start_depth(start_depth),
       _max_count(max_count),
       _frame_buffer(frame_buffer),
@@ -683,7 +684,8 @@ private:
 
 public:
   VM_VirtualThreadGetFrameCount(JvmtiEnv *env, Handle vthread_h, jint* count_ptr)
-    : _vthread_h(vthread_h),
+    : _env(env),
+      _vthread_h(vthread_h),
       _count_ptr(count_ptr),
       _result(JVMTI_ERROR_NONE)
   {}


### PR DESCRIPTION
SonarCloud reports a few uninitialized fields in new VM_Virtual* ops. Those fields are used, and therefore this is a serious bug. These ops seem to be used only from a few corner cases, which is probably why this was never actually found in testing.

Additional testing:
 - [x] Linux x86_64 fastdebug, `jdk_loom hotspot_loom`
 - [x] Linux x86_64 fastdebug, `serviceability/jvmti`

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288324](https://bugs.openjdk.org/browse/JDK-8288324): Loom: Uninitialized JvmtiEnvs in VM_Virtual* ops


### Reviewers
 * [Serguei Spitsyn](https://openjdk.java.net/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [David Holmes](https://openjdk.java.net/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/10/head:pull/10` \
`$ git checkout pull/10`

Update a local copy of the PR: \
`$ git checkout pull/10` \
`$ git pull https://git.openjdk.org/jdk19 pull/10/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 10`

View PR using the GUI difftool: \
`$ git pr show -t 10`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/10.diff">https://git.openjdk.org/jdk19/pull/10.diff</a>

</details>
