### PR TITLE
8278053: serviceability/jvmti/vthread/ContStackDepthTest/ContStackDepthTest.java failing in loom repo with Xcomp

### DIFF
--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1965,6 +1965,9 @@ inline void ThawBase::patch(frame& f, const frame& caller, bool bottom) {
   if (bottom) {
     ContinuationHelper::Frame::patch_pc(caller, _cont.is_empty() ? caller.pc()
                                                                  : StubRoutines::cont_returnBarrier());
+  } else {
+    // caller might have been deoptimized but we've overwritten the return address when copying f
+    ContinuationHelper::Frame::patch_pc(caller, caller.raw_pc());
   }
 
   patch_pd(f, caller);

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1966,7 +1966,7 @@ inline void ThawBase::patch(frame& f, const frame& caller, bool bottom) {
     ContinuationHelper::Frame::patch_pc(caller, _cont.is_empty() ? caller.pc()
                                                                  : StubRoutines::cont_returnBarrier());
   } else {
-    // caller might have been deoptimized but we've overwritten the return address when copying f
+    // caller might have been deoptimized during thaw but we've overwritten the return address when copying f
     ContinuationHelper::Frame::patch_pc(caller, caller.raw_pc());
   }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1966,7 +1966,8 @@ inline void ThawBase::patch(frame& f, const frame& caller, bool bottom) {
     ContinuationHelper::Frame::patch_pc(caller, _cont.is_empty() ? caller.pc()
                                                                  : StubRoutines::cont_returnBarrier());
   } else {
-    // caller might have been deoptimized during thaw but we've overwritten the return address when copying f
+    // caller might have been deoptimized during thaw but we've overwritten the return address when copying f from the heap.
+    // If f is not deoptimized, pc is unchanged.
     ContinuationHelper::Frame::patch_pc(caller, caller.raw_pc());
   }
 

--- a/src/hotspot/share/runtime/continuationFreezeThaw.cpp
+++ b/src/hotspot/share/runtime/continuationFreezeThaw.cpp
@@ -1967,7 +1967,7 @@ inline void ThawBase::patch(frame& f, const frame& caller, bool bottom) {
                                                                  : StubRoutines::cont_returnBarrier());
   } else {
     // caller might have been deoptimized during thaw but we've overwritten the return address when copying f from the heap.
-    // If f is not deoptimized, pc is unchanged.
+    // If the caller is not deoptimized, pc is unchanged.
     ContinuationHelper::Frame::patch_pc(caller, caller.raw_pc());
   }
 

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -31,9 +31,6 @@ vmTestbase/nsk/jvmti/AttachOnDemand/attach022/TestDescription.java 8277573 gener
 
 vmTestbase/nsk/jvmti/SetFieldAccessWatch/setfldw001/TestDescription.java 8205957 generic-all
 
-serviceability/jvmti/vthread/ContFramePopTest/ContFramePopTest.java 8278053 generic-all
-serviceability/jvmti/vthread/ContStackDepthTest/ContStackDepthTest.java 8278053 generic-all
-
 serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64


### PR DESCRIPTION
Please review the following fix.

When JVM TI puts a thread's state in `interp_only_mode`, thaw takes the slow path and deoptimizes frames as they're thawed in `recurse_thaw_compiled_frame`. However, thawing a deoptimized frame's callee will override the frame's patched pc (to the deopt handler), essentially reverting the deoptimization. This fix patches the deoptimized return address after thawing the callee.

Passes loom tiers 1-5

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8278053](https://bugs.openjdk.org/browse/JDK-8278053): serviceability/jvmti/vthread/ContStackDepthTest/ContStackDepthTest.java failing in loom repo with Xcomp


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**) ⚠️ Review applies to [c34a25ac](https://git.openjdk.org/jdk19/pull/12/files/c34a25ac00c59b3f34714c2d3a79e6e313e511f2)
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**) ⚠️ Review applies to [c34a25ac](https://git.openjdk.org/jdk19/pull/12/files/c34a25ac00c59b3f34714c2d3a79e6e313e511f2)
 * [Coleen Phillimore](https://openjdk.org/census#coleenp) (@coleenp - **Reviewer**) ⚠️ Review applies to [c34a25ac](https://git.openjdk.org/jdk19/pull/12/files/c34a25ac00c59b3f34714c2d3a79e6e313e511f2)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/12/head:pull/12` \
`$ git checkout pull/12`

Update a local copy of the PR: \
`$ git checkout pull/12` \
`$ git pull https://git.openjdk.org/jdk19 pull/12/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 12`

View PR using the GUI difftool: \
`$ git pr show -t 12`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/12.diff">https://git.openjdk.org/jdk19/pull/12.diff</a>

</details>
