### PR TITLE
8288289: Preview APIs in jdk.jdi, jdk.management, and jdk.jfr should be reflective preview APIs

### DIFF
--- a/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/ThreadReference.java
@@ -518,7 +518,7 @@ public interface ThreadReference extends ObjectReference {
      *
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     default boolean isVirtual() {
         throw new UnsupportedOperationException("Method not implemented");
     }

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/ThreadDeathRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/ThreadDeathRequest.java
@@ -72,7 +72,7 @@ public interface ThreadDeathRequest extends EventRequest {
      *
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     default void addPlatformThreadsOnlyFilter() {
         throw new UnsupportedOperationException("Method not implemented");
     }

--- a/src/jdk.jdi/share/classes/com/sun/jdi/request/ThreadStartRequest.java
+++ b/src/jdk.jdi/share/classes/com/sun/jdi/request/ThreadStartRequest.java
@@ -72,7 +72,7 @@ public interface ThreadStartRequest extends EventRequest {
      *
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     default void addPlatformThreadsOnlyFilter() {
         throw new UnsupportedOperationException("Method not implemented");
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -110,7 +110,7 @@ public final class RecordedThread extends RecordedObject {
      *
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     public boolean isVirtual() {
         return getTyped("virtual", Boolean.class, Boolean.FALSE);
     }

--- a/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
+++ b/src/jdk.management/share/classes/com/sun/management/HotSpotDiagnosticMXBean.java
@@ -149,7 +149,7 @@ public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
      * @throws UnsupportedOperationException if this operation is not supported
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     default void dumpThreads(String outputFile, ThreadDumpFormat format) throws IOException {
         throw new UnsupportedOperationException();
     }
@@ -158,7 +158,7 @@ public interface HotSpotDiagnosticMXBean extends PlatformManagedObject {
      * Thread dump format.
      * @since 19
      */
-    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS)
+    @PreviewFeature(feature = PreviewFeature.Feature.VIRTUAL_THREADS, reflective = true)
     public static enum ThreadDumpFormat {
         /**
          * Plain text format.


### PR DESCRIPTION
A number of the preview APIs added by JEP 425 exist to expose and support the virtual threads preview feature. Some of these APIs should be changed to be reflective preview APIs (see JEP 12). This will allow debuggers and other tooling to get a jump on  virtual threads without opting in themselves.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.java.net/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8288289](https://bugs.openjdk.org/browse/JDK-8288289): Preview APIs in jdk.jdi, jdk.management, and jdk.jfr should be reflective preview APIs
 * [JDK-8288422](https://bugs.openjdk.org/browse/JDK-8288422): Preview APIs in jdk.jdi, jdk.management, and jdk.jfr should be reflective preview APIs (**CSR**)


### Reviewers
 * [Chris Plummer](https://openjdk.java.net/census#cjplummer) (@plummercj - **Reviewer**)
 * [Jan Lahoda](https://openjdk.java.net/census#jlahoda) (@lahodaj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/13/head:pull/13` \
`$ git checkout pull/13`

Update a local copy of the PR: \
`$ git checkout pull/13` \
`$ git pull https://git.openjdk.org/jdk19 pull/13/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 13`

View PR using the GUI difftool: \
`$ git pr show -t 13`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/13.diff">https://git.openjdk.org/jdk19/pull/13.diff</a>

</details>
