### PR TITLE
8288397: AArch64: Fix register issues in SVE backend match rules

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64_sve.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_sve.ad
@@ -1163,30 +1163,30 @@ instruct vnotL(vReg dst, vReg src, immL_M1 m1) %{
 
 // vector not - predicated
 
-instruct vnotI_masked(vReg dst, vReg src, immI_M1 m1, pRegGov pg) %{
+instruct vnotI_masked(vReg dst_src, immI_M1 m1, pRegGov pg) %{
   predicate(UseSVE > 0);
-  match(Set dst (XorV (Binary src (ReplicateB m1)) pg));
-  match(Set dst (XorV (Binary src (ReplicateS m1)) pg));
-  match(Set dst (XorV (Binary src (ReplicateI m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateB m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateS m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateI m1)) pg));
   ins_cost(SVE_COST);
-  format %{ "sve_not $dst, $pg, $src\t# vector (sve) B/H/S" %}
+  format %{ "sve_not $dst_src, $pg, $dst_src\t# vector (sve) B/H/S" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_not(as_FloatRegister($dst$$reg), __ elemType_to_regVariant(bt),
-               as_PRegister($pg$$reg), as_FloatRegister($src$$reg));
+    __ sve_not(as_FloatRegister($dst_src$$reg), __ elemType_to_regVariant(bt),
+               as_PRegister($pg$$reg), as_FloatRegister($dst_src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
 
-instruct vnotL_masked(vReg dst, vReg src, immL_M1 m1, pRegGov pg) %{
+instruct vnotL_masked(vReg dst_src, immL_M1 m1, pRegGov pg) %{
   predicate(UseSVE > 0);
-  match(Set dst (XorV (Binary src (ReplicateL m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateL m1)) pg));
   ins_cost(SVE_COST);
-  format %{ "sve_not $dst, $pg, $src\t# vector (sve) D" %}
+  format %{ "sve_not $dst_src, $pg, $dst_src\t# vector (sve) D" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_not(as_FloatRegister($dst$$reg), __ elemType_to_regVariant(bt),
-               as_PRegister($pg$$reg), as_FloatRegister($src$$reg));
+    __ sve_not(as_FloatRegister($dst_src$$reg), __ elemType_to_regVariant(bt),
+               as_PRegister($pg$$reg), as_FloatRegister($dst_src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5254,18 +5254,19 @@ instruct gatherI(vReg dst, indirect mem, vReg idx) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL(vReg dst, indirect mem, vReg idx) %{
+instruct gatherL(vReg dst, indirect mem, vReg idx, vReg tmp) %{
   predicate(UseSVE > 0 &&
             n->as_LoadVectorGather()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGather mem idx));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "load_vector_gather $dst, $mem, $idx\t# vector load gather (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), ptrue, as_Register($mem$$base),
-                       as_FloatRegister($idx$$reg));
+                       as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5289,20 +5290,20 @@ instruct gatherI_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsReg cr) %{
+instruct gatherL_partial(vReg dst, indirect mem, vReg idx, vReg vtmp, pRegGov ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             n->as_LoadVectorGather()->memory_size() < MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGather mem idx));
-  effect(TEMP ptmp, KILL cr);
+  effect(TEMP vtmp, TEMP ptmp, KILL cr);
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (D)" %}
   ins_encode %{
     __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($vtmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                       as_Register($mem$$base), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5323,17 +5324,18 @@ instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
+instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg, vReg tmp) %{
   predicate(UseSVE > 0 &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($pg$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                       as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5355,18 +5357,19 @@ instruct scatterI(indirect mem, vReg src, vReg idx) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL(indirect mem, vReg src, vReg idx) %{
+instruct scatterL(indirect mem, vReg src, vReg idx, vReg tmp) %{
   predicate(UseSVE > 0 &&
             n->as_StoreVectorScatter()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "store_vector_scatter $mem, $idx, $src\t# vector store scatter (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), ptrue,
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5390,20 +5393,20 @@ instruct scatterI_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlagsReg cr) %{
+instruct scatterL_partial(indirect mem, vReg src, vReg idx, vReg vtmp, pRegGov ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             n->as_StoreVectorScatter()->memory_size() < MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
-  effect(TEMP ptmp, KILL cr);
+  effect(TEMP vtmp, TEMP ptmp, KILL cr);
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (D)" %}
   ins_encode %{
     __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($vtmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -5424,17 +5427,18 @@ instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
+instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg, vReg tmp) %{
   predicate(UseSVE > 0 &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($pg$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_sve_ad.m4
@@ -657,21 +657,21 @@ dnl
 // vector not - predicated
 dnl
 define(`MATCH_RULE', `ifelse($1, I,
-`match(Set dst (XorV (Binary src (ReplicateB m1)) pg));
-  match(Set dst (XorV (Binary src (ReplicateS m1)) pg));
-  match(Set dst (XorV (Binary src (ReplicateI m1)) pg));',
-`match(Set dst (XorV (Binary src (ReplicateL m1)) pg));')')dnl
+`match(Set dst_src (XorV (Binary dst_src (ReplicateB m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateS m1)) pg));
+  match(Set dst_src (XorV (Binary dst_src (ReplicateI m1)) pg));',
+`match(Set dst_src (XorV (Binary dst_src (ReplicateL m1)) pg));')')dnl
 dnl
 define(`VECTOR_NOT_PREDICATE', `
-instruct vnot$1_masked`'(vReg dst, vReg src, imm$1_M1 m1, pRegGov pg) %{
+instruct vnot$1_masked`'(vReg dst_src, imm$1_M1 m1, pRegGov pg) %{
   predicate(UseSVE > 0);
   MATCH_RULE($1)
   ins_cost(SVE_COST);
-  format %{ "sve_not $dst, $pg, $src\t# vector (sve) $2" %}
+  format %{ "sve_not $dst_src, $pg, $dst_src\t# vector (sve) $2" %}
   ins_encode %{
     BasicType bt = Matcher::vector_element_basic_type(this);
-    __ sve_not(as_FloatRegister($dst$$reg), __ elemType_to_regVariant(bt),
-               as_PRegister($pg$$reg), as_FloatRegister($src$$reg));
+    __ sve_not(as_FloatRegister($dst_src$$reg), __ elemType_to_regVariant(bt),
+               as_PRegister($pg$$reg), as_FloatRegister($dst_src$$reg));
   %}
   ins_pipe(pipe_slow);
 %}')dnl
@@ -2824,18 +2824,19 @@ instruct gatherI(vReg dst, indirect mem, vReg idx) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL(vReg dst, indirect mem, vReg idx) %{
+instruct gatherL(vReg dst, indirect mem, vReg idx, vReg tmp) %{
   predicate(UseSVE > 0 &&
             n->as_LoadVectorGather()->memory_size() == MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGather mem idx));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "load_vector_gather $dst, $mem, $idx\t# vector load gather (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), ptrue, as_Register($mem$$base),
-                       as_FloatRegister($idx$$reg));
+                       as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2859,20 +2860,20 @@ instruct gatherI_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsR
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL_partial(vReg dst, indirect mem, vReg idx, pRegGov ptmp, rFlagsReg cr) %{
+instruct gatherL_partial(vReg dst, indirect mem, vReg idx, vReg vtmp, pRegGov ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             n->as_LoadVectorGather()->memory_size() < MaxVectorSize &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGather mem idx));
-  effect(TEMP ptmp, KILL cr);
+  effect(TEMP vtmp, TEMP ptmp, KILL cr);
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "load_vector_gather $dst, $ptmp, $mem, $idx\t# vector load gather partial (D)" %}
   ins_encode %{
     __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($vtmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($ptmp$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                       as_Register($mem$$base), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2893,17 +2894,18 @@ instruct gatherI_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg) %{
+instruct gatherL_masked(vReg dst, indirect mem, vReg idx, pRegGov pg, vReg tmp) %{
   predicate(UseSVE > 0 &&
             (n->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set dst (LoadVectorGatherMasked mem (Binary idx pg)));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "load_vector_gather $dst, $pg, $mem, $idx\t# vector load gather predicated (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_ld1d_gather(as_FloatRegister($dst$$reg), as_PRegister($pg$$reg),
-                       as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                       as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2925,18 +2927,19 @@ instruct scatterI(indirect mem, vReg src, vReg idx) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL(indirect mem, vReg src, vReg idx) %{
+instruct scatterL(indirect mem, vReg src, vReg idx, vReg tmp) %{
   predicate(UseSVE > 0 &&
             n->as_StoreVectorScatter()->memory_size() == MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "store_vector_scatter $mem, $idx, $src\t# vector store scatter (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), ptrue,
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2960,20 +2963,20 @@ instruct scatterI_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlags
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL_partial(indirect mem, vReg src, vReg idx, pRegGov ptmp, rFlagsReg cr) %{
+instruct scatterL_partial(indirect mem, vReg src, vReg idx, vReg vtmp, pRegGov ptmp, rFlagsReg cr) %{
   predicate(UseSVE > 0 &&
             n->as_StoreVectorScatter()->memory_size() < MaxVectorSize &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatter mem (Binary src idx)));
-  effect(TEMP ptmp, KILL cr);
+  effect(TEMP vtmp, TEMP ptmp, KILL cr);
   ins_cost(3 * SVE_COST + INSN_COST);
   format %{ "store_vector_scatter $mem, $ptmp, $idx, $src\t# vector store scatter partial (D)" %}
   ins_encode %{
     __ sve_ptrue_lanecnt(as_PRegister($ptmp$$reg), __ D, Matcher::vector_length(this, $src));
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($vtmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($ptmp$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($vtmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}
@@ -2994,17 +2997,18 @@ instruct scatterI_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
   ins_pipe(pipe_slow);
 %}
 
-instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg) %{
+instruct scatterL_masked(indirect mem, vReg src, vReg idx, pRegGov pg, vReg tmp) %{
   predicate(UseSVE > 0 &&
             (n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_LONG ||
              n->in(3)->in(1)->bottom_type()->is_vect()->element_basic_type() == T_DOUBLE));
   match(Set mem (StoreVectorScatterMasked mem (Binary src (Binary idx pg))));
+  effect(TEMP tmp);
   ins_cost(2 * SVE_COST);
   format %{ "store_vector_scatter $mem, $pg, $idx, $src\t# vector store scatter predicated (D)" %}
   ins_encode %{
-    __ sve_uunpklo(as_FloatRegister($idx$$reg), __ D, as_FloatRegister($idx$$reg));
+    __ sve_uunpklo(as_FloatRegister($tmp$$reg), __ D, as_FloatRegister($idx$$reg));
     __ sve_st1d_scatter(as_FloatRegister($src$$reg), as_PRegister($pg$$reg),
-                        as_Register($mem$$base), as_FloatRegister($idx$$reg));
+                        as_Register($mem$$base), as_FloatRegister($tmp$$reg));
   %}
   ins_pipe(pipe_slow);
 %}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorGatherScatterTest.java
@@ -1,0 +1,148 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.DoubleVector;
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorShape;
+import jdk.incubator.vector.VectorSpecies;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8288397
+ * @key randomness
+ * @library /test/lib /
+ * @requires vm.cpu.features ~= ".*sve.*"
+ * @summary AArch64: Fix register issues in SVE backend match rules
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorGatherScatterTest
+ */
+
+public class VectorGatherScatterTest {
+    private static final VectorSpecies<Double> D_SPECIES = DoubleVector.SPECIES_MAX;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+    private static final VectorSpecies<Integer> I_SPECIES =
+        VectorSpecies.of(int.class, VectorShape.forBitSize(L_SPECIES.vectorBitSize() / 2));
+
+    private static int LENGTH = 128;
+    private static final Random RD = Utils.getRandomInstance();
+
+    private static int[] ia;
+    private static int[] ir;
+    private static long[] la;
+    private static long[] lr;
+    private static double[] da;
+    private static double[] dr;
+    private static boolean[] m;
+
+    static {
+        ia = new int[LENGTH];
+        ir = new int[LENGTH];
+        la = new long[LENGTH];
+        lr = new long[LENGTH];
+        da = new double[LENGTH];
+        dr = new double[LENGTH];
+        m = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            ia[i] = i;
+            la[i] = RD.nextLong(25);
+            da[i] = RD.nextDouble(25.0);
+            m[i] = RD.nextBoolean();
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "LoadVectorGather", ">= 1" })
+    public static void testLoadGather() {
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0, ia, 0);
+        av.intoArray(lr, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
+        bv.add(0).intoArray(ir, 0);
+
+        for(int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ia[i], ir[i]);
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "LoadVectorGatherMasked", ">= 1" })
+    public static void testLoadGatherMasked() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0, ia, 0, mask);
+        av.intoArray(lr, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
+        bv.add(0).intoArray(ir, 0);
+
+        for(int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ia[i], ir[i]);
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "StoreVectorScatter", ">= 1" })
+    public static void testStoreScatter() {
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        av.intoArray(dr, 0, ia, 0);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
+        bv.add(0).intoArray(ir, 0);
+
+        for(int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ia[i], ir[i]);
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "StoreVectorScatterMasked", ">= 1" })
+    public static void testStoreScatterMasked() {
+        VectorMask<Double> mask = VectorMask.fromArray(D_SPECIES, m, 0);
+        DoubleVector av = DoubleVector.fromArray(D_SPECIES, da, 0);
+        av.intoArray(dr, 0, ia, 0, mask);
+        IntVector bv = IntVector.fromArray(I_SPECIES, ia, 0);
+        bv.add(0).intoArray(ir, 0);
+
+        for(int i = 0; i < I_SPECIES.length(); i++) {
+            Asserts.assertEquals(ia[i], ir[i]);
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector",
+                                   "-XX:UseSVE=1");
+    }
+}

--- a/test/hotspot/jtreg/compiler/vectorapi/VectorMaskedNotTest.java
+++ b/test/hotspot/jtreg/compiler/vectorapi/VectorMaskedNotTest.java
@@ -1,0 +1,118 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+package compiler.vectorapi;
+
+import compiler.lib.ir_framework.*;
+
+import java.util.Random;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.LongVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorOperators;
+import jdk.incubator.vector.VectorSpecies;
+
+import jdk.test.lib.Asserts;
+import jdk.test.lib.Utils;
+
+/**
+ * @test
+ * @bug 8288397
+ * @key randomness
+ * @library /test/lib /
+ * @requires vm.cpu.features ~= ".*sve.*"
+ * @summary AArch64: Fix register issues in SVE backend match rules
+ * @modules jdk.incubator.vector
+ *
+ * @run driver compiler.vectorapi.VectorMaskedNotTest
+ */
+
+public class VectorMaskedNotTest {
+    private static final VectorSpecies<Integer> I_SPECIES = IntVector.SPECIES_MAX;
+    private static final VectorSpecies<Long> L_SPECIES = LongVector.SPECIES_MAX;
+
+    private static int LENGTH = 128;
+    private static final Random RD = Utils.getRandomInstance();
+
+    private static int[] ia;
+    private static int[] ir;
+    private static long[] la;
+    private static long[] lr;
+    private static boolean[] m;
+
+    static {
+        ia = new int[LENGTH];
+        ir = new int[LENGTH];
+        la = new long[LENGTH];
+        lr = new long[LENGTH];
+        m = new boolean[LENGTH];
+
+        for (int i = 0; i < LENGTH; i++) {
+            ia[i] = RD.nextInt(25);
+            la[i] = RD.nextLong(25);
+            m[i] = RD.nextBoolean();
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "sve_not", ">= 1" })
+    public static void testIntNotMasked() {
+        VectorMask<Integer> mask = VectorMask.fromArray(I_SPECIES, m, 0);
+        IntVector av = IntVector.fromArray(I_SPECIES, ia, 0);
+        av.lanewise(VectorOperators.NOT, mask).add(av).intoArray(ir, 0);
+
+        // Verify results
+        for (int i = 0; i < I_SPECIES.length(); i++) {
+            if (m[i]) {
+                Asserts.assertEquals((~ia[i]) + ia[i], ir[i]);
+            } else {
+                Asserts.assertEquals(ia[i] + ia[i], ir[i]);
+            }
+        }
+    }
+
+    @Test
+    @Warmup(10000)
+    @IR(counts = { "sve_not", ">= 1" })
+    public static void testLongNotMasked() {
+        VectorMask<Long> mask = VectorMask.fromArray(L_SPECIES, m, 0);
+        LongVector av = LongVector.fromArray(L_SPECIES, la, 0);
+        av.lanewise(VectorOperators.NOT, mask).add(av).intoArray(lr, 0);
+
+        // Verify results
+        for (int i = 0; i < L_SPECIES.length(); i++) {
+            if (m[i]) {
+                Asserts.assertEquals((~la[i]) + la[i], lr[i]);
+            } else {
+                Asserts.assertEquals(la[i] + la[i], lr[i]);
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        TestFramework.runWithFlags("--add-modules=jdk.incubator.vector",
+                                   "-XX:UseSVE=1");
+    }
+}


### PR DESCRIPTION
There are register usage issues in the sve backend match rules, which made the two added jtreg tests fail.

The predicated vector "`not`" rules didn't use the same register for "`src`" and "`dst`", which is necessary to make sure the inactive lanes in "`dst`" save the same elements as "`src`". This patch fixes the rules by using the same register for "`dst`" and "`src`".

And the input idx register in "`gatherL/scatterL`" rules was overwritten by the first unpack instruction. The same issue also existed in the partial and predicated gatherL/scatterL rules. This patch fixes them by saving the unpack results into a temp register and use it as the index for gather/scatter.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288397](https://bugs.openjdk.org/browse/JDK-8288397): AArch64: Fix register issues in SVE backend match rules


### Reviewers
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)
 * [Nick Gasson](https://openjdk.org/census#ngasson) (@nick-arm - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/17/head:pull/17` \
`$ git checkout pull/17`

Update a local copy of the PR: \
`$ git checkout pull/17` \
`$ git pull https://git.openjdk.org/jdk19 pull/17/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 17`

View PR using the GUI difftool: \
`$ git pr show -t 17`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/17.diff">https://git.openjdk.org/jdk19/pull/17.diff</a>

</details>
