### PR TITLE
8288485: jni/nullCaller/NullCallerTest.java failing (ppc64)

### DIFF
--- a/test/jdk/jni/nullCaller/CallHelper.hpp
+++ b/test/jdk/jni/nullCaller/CallHelper.hpp
@@ -24,12 +24,12 @@
 #define __CallHelper_hpp__
 
 #include <stdlib.h>
+#include <stdio.h>
 #include <jni.h>
 #undef NDEBUG
 #include <assert.h>
 #include <string>
 #include <algorithm>
-#include <iostream>
 
 /*
  * basis of classes to provide a bunch of checking in native calls to java
@@ -48,7 +48,7 @@ protected:
     void emitErrorMessage(const std::string& msg) {
         std::string nm = classname;
         std::replace(nm.begin(), nm.end(), '/', '.');
-        std::cerr << "ERROR: " << nm << "::" << method << ", " << msg << std::endl;
+        ::fprintf(stderr, "ERROR: %s::%s, %s\n", nm.c_str(), method.c_str(), msg.c_str());
     }
 
     // check the given object which is expected to be null
@@ -202,7 +202,7 @@ public:
 };
 
 void emitErrorMessageAndExit(const std::string& msg) {
-    std::cerr << "ERROR: " << msg << std::endl;
+    ::fprintf(stderr, "ERROR: %s\n", msg.c_str());
     ::exit(-1);
 }
 


### PR DESCRIPTION
I'd like to revert to "<stdio.h>" functions like it was before [JDK-8281001](https://bugs.openjdk.org/browse/JDK-8281001), except that I'm using stderr in order to preserve the new behavior. Also see JBS issue.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288485](https://bugs.openjdk.org/browse/JDK-8288485): jni/nullCaller/NullCallerTest.java failing (ppc64)


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * @parttimenerd (no known github.com user name / role)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/19/head:pull/19` \
`$ git checkout pull/19`

Update a local copy of the PR: \
`$ git checkout pull/19` \
`$ git pull https://git.openjdk.org/jdk19 pull/19/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 19`

View PR using the GUI difftool: \
`$ git pr show -t 19`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/19.diff">https://git.openjdk.org/jdk19/pull/19.diff</a>

</details>
