### PR TITLE
8288497: add support for JavaThread::is_oop_safe()

### DIFF
--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -3598,6 +3598,12 @@ void Threads::remove(JavaThread* p, bool is_daemon) {
     // StackWatermarkSet::on_safepoint(), which performs GC processing,
     // requiring the GC state to be alive.
     BarrierSet::barrier_set()->on_thread_detach(p);
+    if (p->is_exiting()) {
+      // If we got here via JavaThread::exit(), then we remember that the
+      // thread's GC barrier has been detached. We don't do this when we get
+      // here from another path, e.g., cleanup_failed_attach_current_thread().
+      p->set_terminated(JavaThread::_thread_gc_barrier_detached);
+    }
 
     assert(ThreadsSMRSupport::get_java_thread_list()->includes(p), "p must be present");
 

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -1180,8 +1180,8 @@ private:
   // thread has called JavaThread::exit(), thread's GC barrier is detached
   // or thread is terminated
   bool is_exiting() const;
-  // thread's GC barrier is detached or thread is terminated
-  bool cannot_access_oops_safely() const;
+  // thread's GC barrier is NOT detached and thread is NOT terminated
+  bool is_oop_safe() const;
   // thread is terminated (no longer on the threads list); we compare
   // against the three non-terminated values so that a freed JavaThread
   // will also be considered terminated.

--- a/src/hotspot/share/runtime/thread.hpp
+++ b/src/hotspot/share/runtime/thread.hpp
@@ -919,6 +919,10 @@ class JavaThread: public Thread {
   //
   // _vm_exited is a special value to cover the case of a JavaThread
   // executing native code after the VM itself is terminated.
+  //
+  // A JavaThread that fails to JNI attach has these _terminated field transitions:
+  //   _not_terminated => _thread_terminated
+  //
   volatile TerminatedTypes _terminated;
 
   jint                  _in_deopt_handler;       // count of deoptimization
@@ -1177,7 +1181,7 @@ private:
   // or thread is terminated
   bool is_exiting() const;
   // thread's GC barrier is detached or thread is terminated
-  bool is_gc_barrier_detached() const;
+  bool cannot_access_oops_safely() const;
   // thread is terminated (no longer on the threads list); we compare
   // against the three non-terminated values so that a freed JavaThread
   // will also be considered terminated.

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -266,10 +266,10 @@ inline bool JavaThread::is_exiting() const {
          check_is_terminated(l_terminated);
 }
 
-inline bool JavaThread::cannot_access_oops_safely() const {
+inline bool JavaThread::is_oop_safe() const {
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
-  return l_terminated == _thread_gc_barrier_detached ||
-         check_is_terminated(l_terminated);
+  return l_terminated != _thread_gc_barrier_detached &&
+         !check_is_terminated(l_terminated);
 }
 
 inline bool JavaThread::is_terminated() const {

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -261,14 +261,24 @@ inline void JavaThread::set_done_attaching_via_jni() {
 
 inline bool JavaThread::is_exiting() const {
   // Use load-acquire so that setting of _terminated by
-  // JavaThread::exit() is seen more quickly.
+  // JavaThread::set_terminated() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
-  return l_terminated == _thread_exiting || check_is_terminated(l_terminated);
+  return l_terminated == _thread_exiting ||
+         l_terminated == _thread_gc_barrier_detached ||
+         check_is_terminated(l_terminated);
+}
+
+inline bool JavaThread::is_gc_barrier_detached() const {
+  // Use load-acquire so that setting of _terminated by
+  // JavaThread::set_terminated() is seen more quickly.
+  TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
+  return l_terminated == _thread_gc_barrier_detached ||
+         check_is_terminated(l_terminated);
 }
 
 inline bool JavaThread::is_terminated() const {
   // Use load-acquire so that setting of _terminated by
-  // JavaThread::exit() is seen more quickly.
+  // JavaThread::set_terminated() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
   return check_is_terminated(l_terminated);
 }

--- a/src/hotspot/share/runtime/thread.inline.hpp
+++ b/src/hotspot/share/runtime/thread.inline.hpp
@@ -260,31 +260,24 @@ inline void JavaThread::set_done_attaching_via_jni() {
 }
 
 inline bool JavaThread::is_exiting() const {
-  // Use load-acquire so that setting of _terminated by
-  // JavaThread::set_terminated() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
   return l_terminated == _thread_exiting ||
          l_terminated == _thread_gc_barrier_detached ||
          check_is_terminated(l_terminated);
 }
 
-inline bool JavaThread::is_gc_barrier_detached() const {
-  // Use load-acquire so that setting of _terminated by
-  // JavaThread::set_terminated() is seen more quickly.
+inline bool JavaThread::cannot_access_oops_safely() const {
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
   return l_terminated == _thread_gc_barrier_detached ||
          check_is_terminated(l_terminated);
 }
 
 inline bool JavaThread::is_terminated() const {
-  // Use load-acquire so that setting of _terminated by
-  // JavaThread::set_terminated() is seen more quickly.
   TerminatedTypes l_terminated = Atomic::load_acquire(&_terminated);
   return check_is_terminated(l_terminated);
 }
 
 inline void JavaThread::set_terminated(TerminatedTypes t) {
-  // use release-store so the setting of _terminated is seen more quickly
   Atomic::release_store(&_terminated, t);
 }
 

--- a/src/hotspot/share/services/threadService.cpp
+++ b/src/hotspot/share/services/threadService.cpp
@@ -163,7 +163,8 @@ void ThreadService::remove_thread(JavaThread* thread, bool daemon) {
 
   assert(!thread->is_terminated(), "must not be terminated");
   if (!thread->is_exiting()) {
-    // JavaThread::exit() skipped calling current_thread_exiting()
+    // We did not get here via JavaThread::exit() so current_thread_exiting()
+    // was not called, e.g., JavaThread::cleanup_failed_attach_current_thread().
     decrement_thread_counts(thread, daemon);
   }
 


### PR DESCRIPTION
A fix to add support for JavaThread::is_gc_barrier_detached() which allows
us to add checks to detect failures like:

    JDK-8288139 JavaThread touches oop after GC barrier is detached
    https://bugs.openjdk.org/browse/JDK-8288139

This fix along with the fix for JDK-8288139 has been tested in Mach5 Tier[1-8].
There are no related failures in Mach5 Tier[1-7]; Mach5 Tier8 is still running.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288497](https://bugs.openjdk.org/browse/JDK-8288497): add support for JavaThread::is_oop_safe()


### Reviewers
 * [Patricio Chilano Mateo](https://openjdk.org/census#pchilanomate) (@pchilano - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**) ⚠️ Review applies to [24ecdea4](https://git.openjdk.org/jdk19/pull/20/files/24ecdea4f0111057faf805c89d6bf1033f27b707)
 * [Erik Österlund](https://openjdk.org/census#eosterlund) (@fisk - **Reviewer**) ⚠️ Review applies to [24ecdea4](https://git.openjdk.org/jdk19/pull/20/files/24ecdea4f0111057faf805c89d6bf1033f27b707)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/20/head:pull/20` \
`$ git checkout pull/20`

Update a local copy of the PR: \
`$ git checkout pull/20` \
`$ git pull https://git.openjdk.org/jdk19 pull/20/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 20`

View PR using the GUI difftool: \
`$ git pr show -t 20`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/20.diff">https://git.openjdk.org/jdk19/pull/20.diff</a>

</details>
