### PR TITLE
8288534: Out of bound errors for memory segment access mentions wrong values

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/AbstractMemorySegmentImpl.java
@@ -41,6 +41,7 @@ import java.nio.IntBuffer;
 import java.nio.LongBuffer;
 import java.nio.ShortBuffer;
 import java.util.*;
+import java.util.function.BiFunction;
 import java.util.function.Consumer;
 import java.util.function.Function;
 import java.util.function.IntFunction;
@@ -51,6 +52,7 @@ import jdk.internal.access.SharedSecrets;
 import jdk.internal.access.foreign.UnmapperProxy;
 import jdk.internal.misc.ScopedMemoryAccess;
 import jdk.internal.util.ArraysSupport;
+import jdk.internal.util.Preconditions;
 import jdk.internal.vm.annotation.ForceInline;
 
 import static java.lang.foreign.ValueLayout.JAVA_BYTE;
@@ -64,7 +66,7 @@ import static java.lang.foreign.ValueLayout.JAVA_BYTE;
  * are defined for each memory segment kind, see {@link NativeMemorySegmentImpl}, {@link HeapMemorySegmentImpl} and
  * {@link MappedMemorySegmentImpl}.
  */
-public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegment, SegmentAllocator, Scoped {
+public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegment, SegmentAllocator, Scoped, BiFunction<String, List<Number>, RuntimeException> {
 
     private static final ScopedMemoryAccess SCOPED_MEMORY_ACCESS = ScopedMemoryAccess.getScopedMemoryAccess();
 
@@ -394,11 +396,18 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     @ForceInline
     void checkBounds(long offset, long length) {
         if (length > 0) {
-            Objects.checkIndex(offset, this.length - length + 1);
+            Preconditions.checkIndex(offset, this.length - length + 1, this);
         } else if (length < 0 || offset < 0 ||
                 offset > this.length - length) {
             throw outOfBoundException(offset, length);
         }
+    }
+
+    @Override
+    public RuntimeException apply(String s, List<Number> numbers) {
+        long offset = numbers.get(0).longValue();
+        long length = byteSize() - numbers.get(1).longValue() + 1;
+        return outOfBoundException(offset, length);
     }
 
     @Override
@@ -413,7 +422,7 @@ public abstract non-sealed class AbstractMemorySegmentImpl implements MemorySegm
     }
 
     private IndexOutOfBoundsException outOfBoundException(long offset, long length) {
-        return new IndexOutOfBoundsException(String.format("Out of bound access on segment %s; new offset = %d; new length = %d",
+        return new IndexOutOfBoundsException(String.format("Out of bound access on segment %s; offset = %d; length = %d",
                         this, offset, length));
     }
 

--- a/test/jdk/java/foreign/TestSegments.java
+++ b/test/jdk/java/foreign/TestSegments.java
@@ -154,6 +154,18 @@ public class TestSegments {
         memorySegment.get(JAVA_INT, offset);
     }
 
+    @Test
+    public void testSegmentOOBMessage() {
+        try {
+            var segment = MemorySegment.allocateNative(10, MemorySession.global());
+            segment.getAtIndex(ValueLayout.JAVA_INT, 2);
+        } catch (IndexOutOfBoundsException ex) {
+            assertTrue(ex.getMessage().contains("Out of bound access"));
+            assertTrue(ex.getMessage().contains("offset = 8"));
+            assertTrue(ex.getMessage().contains("length = 4"));
+        }
+    }
+
     @Test(dataProvider = "segmentFactories")
     public void testAccessModesOfFactories(Supplier<MemorySegment> segmentSupplier) {
         MemorySegment segment = segmentSupplier.get();


### PR DESCRIPTION
While playing with the API, I've realized that some of the out of bound error messgaes come out incorrectly.

This is because the bound check is performed as follows (to avoid overflow):

```
Objects.checkIndex(offset, this.length - length + 1);
```

So, if out-of-bounds access is detected, the resulting exception mentions the values of the first and second parameter, respectively - but since the second parameter is the result of a subtraction, it doesn't make sense.

The solution is not to use `Objects.checkIndex` directly, but, instead, drop down one level, and pass our own "IOOB formatter":

```
Preconditions.checkIndex(offset, this.length - length + 1, this);
```

Note that, in order to recover the correct values, the formatter needs to know the segment size - so I made `AbstractMemorySegment` act as a formatter (so we don't need to allocate in such a hot path).

The fix seems to bring back the desired messages - but I would like some confirmation that doing this won't disrupt intrinsification of the `checkIndex` method.

