### PR TITLE
JDK-8288533: Missing @param tags in com.sun.source classes

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePathScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreePathScanner.java
@@ -35,6 +35,12 @@ import com.sun.source.doctree.DocTree;
  * Inside your method, call super.visitXYZ to visit descendant
  * nodes.
  *
+ * @param <R> the return type of this visitor's methods.  Use {@link
+ *            Void} for visitors that do not need to return results.
+ * @param <P> the type of the additional parameter to this visitor's
+ *            methods.  Use {@code Void} for visitors that do not need an
+ *            additional parameter.
+ *
  * @since 1.8
  */
 public class DocTreePathScanner<R, P> extends DocTreeScanner<R, P> {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/DocTreeScanner.java
@@ -66,6 +66,12 @@ import com.sun.source.doctree.*;
  * the last child scanned.
  * </ul>
  *
+ * @param <R> the return type of this visitor's methods.  Use {@link
+ *            Void} for visitors that do not need to return results.
+ * @param <P> the type of the additional parameter to this visitor's
+ *            methods.  Use {@code Void} for visitors that do not need an
+ *            additional parameter.
+ *
  * @since 1.8
  */
 public class DocTreeScanner<R,P> implements DocTreeVisitor<R,P> {

--- a/src/jdk.compiler/share/classes/com/sun/source/util/TreePathScanner.java
+++ b/src/jdk.compiler/share/classes/com/sun/source/util/TreePathScanner.java
@@ -39,6 +39,12 @@ import com.sun.source.tree.*;
  * In order to initialize the "current path", the scan must be
  * started by calling one of the {@code scan} methods.
  *
+ * @param <R> the return type of this visitor's methods.  Use {@link
+ *            Void} for visitors that do not need to return results.
+ * @param <P> the type of the additional parameter to this visitor's
+ *            methods.  Use {@code Void} for visitors that do not need an
+ *            additional parameter.
+ *
  * @author Jonathan Gibbons
  * @since 1.6
  */


### PR DESCRIPTION
Please review a noreg-doc fix to add some missing `@param` tags in the `com.sun.source` API. The added text is boilerplate taken from similar classes.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288533](https://bugs.openjdk.org/browse/JDK-8288533): Missing @param tags in com.sun.source classes


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/25/head:pull/25` \
`$ git checkout pull/25`

Update a local copy of the PR: \
`$ git checkout pull/25` \
`$ git pull https://git.openjdk.org/jdk19 pull/25/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 25`

View PR using the GUI difftool: \
`$ git pr show -t 25`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/25.diff">https://git.openjdk.org/jdk19/pull/25.diff</a>

</details>
