### PR TITLE
8287401: jpackage tests failing on Windows due to powershell issue

### DIFF
--- a/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
+++ b/test/jdk/tools/jpackage/helpers/jdk/jpackage/test/LauncherIconVerifier.java
@@ -28,7 +28,6 @@ import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
 import java.nio.file.Files;
 import java.nio.file.Path;
-import java.util.List;
 import java.util.Optional;
 
 public final class LauncherIconVerifier {
@@ -136,18 +135,16 @@ public final class LauncherIconVerifier {
 
         private Path extractIconFromExecutable(Path outputDir, Path executable,
                 String label) {
-            Path psScript = outputDir.resolve(label + ".ps1");
             Path extractedIcon = outputDir.resolve(label + ".bmp");
-            TKit.createTextFile(psScript, List.of(
+            String script = String.join(";",
                     "[System.Reflection.Assembly]::LoadWithPartialName('System.Drawing')",
                     String.format(
-                            "[System.Drawing.Icon]::ExtractAssociatedIcon(\"%s\").ToBitmap().Save(\"%s\", [System.Drawing.Imaging.ImageFormat]::Bmp)",
+                            "[System.Drawing.Icon]::ExtractAssociatedIcon('%s').ToBitmap().Save('%s', [System.Drawing.Imaging.ImageFormat]::Bmp)",
                             executable.toAbsolutePath().normalize(),
-                            extractedIcon.toAbsolutePath().normalize()),
-                    "exit 0"));
+                            extractedIcon.toAbsolutePath().normalize()));
 
-            Executor.of("powershell", "-NoLogo", "-NoProfile", "-File",
-                    psScript.toAbsolutePath().normalize().toString()).execute();
+            Executor.of("powershell", "-NoLogo", "-NoProfile", "-Command",
+                    script).execute();
 
             return extractedIcon;
         }


### PR DESCRIPTION
Run a script extracting icons from executables as PowerShell command line rather than a script

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287401](https://bugs.openjdk.org/browse/JDK-8287401): jpackage tests failing on Windows due to powershell issue


### Reviewers
 * [Alexander Matveev](https://openjdk.org/census#almatvee) (@sashamatveev - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/26/head:pull/26` \
`$ git checkout pull/26`

Update a local copy of the PR: \
`$ git checkout pull/26` \
`$ git pull https://git.openjdk.org/jdk19 pull/26/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 26`

View PR using the GUI difftool: \
`$ git pr show -t 26`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/26.diff">https://git.openjdk.org/jdk19/pull/26.diff</a>

</details>
