### PR TITLE
8287982: Concurrent implicit attach from native threads crashes VM

### DIFF
--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -86,7 +86,7 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread -ljvm
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -ljvm -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libImplicitAttach := -pthread
   BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c
   ifeq ($(call isTargetOs, linux), true)

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -86,7 +86,8 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := $(LIBCXX) -pthread
-  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -ljvm -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LIBS_libExplicitAttach := -ljvm
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libImplicitAttach := -pthread
   BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c
   ifeq ($(call isTargetOs, linux), true)

--- a/make/test/JtregNativeJdk.gmk
+++ b/make/test/JtregNativeJdk.gmk
@@ -55,7 +55,9 @@ BUILD_JDK_JTREG_EXECUTABLES_CFLAGS_exeJliLaunchTest := \
 
 # Platform specific setup
 ifeq ($(call isTargetOs, windows), true)
-  BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c exelauncher.c
+  BUILD_JDK_JTREG_EXCLUDE += libDirectIO.c libInheritedChannel.c \
+      libExplicitAttach.c libImplicitAttach.c \
+      exelauncher.c
 
   WIN_LIB_JAVA := $(SUPPORT_OUTPUTDIR)/native/java.base/libjava/java.lib
   BUILD_JDK_JTREG_LIBRARIES_LIBS_libstringPlatformChars := $(WIN_LIB_JAVA)
@@ -84,6 +86,8 @@ else
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerUnnamed := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLinkerInvokerModule := $(LIBCXX) -pthread
   BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libLoaderLookupInvoker := $(LIBCXX) -pthread
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libExplicitAttach := -pthread -ljvm
+  BUILD_JDK_JTREG_LIBRARIES_LDFLAGS_libImplicitAttach := -pthread
   BUILD_JDK_JTREG_EXCLUDE += exerevokeall.c
   ifeq ($(call isTargetOs, linux), true)
     BUILD_JDK_JTREG_LIBRARIES_LIBS_libInheritedChannel := -ljava

--- a/src/java.base/share/classes/java/lang/Thread.java
+++ b/src/java.base/share/classes/java/lang/Thread.java
@@ -654,19 +654,19 @@ public class Thread implements Runnable {
            long stackSize, AccessControlContext acc) {
 
         Thread parent = currentThread();
-        boolean attaching = (parent == this);   // primordial or JNI attach
+        boolean attached = (parent == this);   // primordial or JNI attached
 
-        if (attaching) {
+        if (attached) {
             if (g == null) {
                 throw new InternalError("group cannot be null when attaching");
             }
             this.holder = new FieldHolder(g, task, stackSize, NORM_PRIORITY, false);
         } else {
-            SecurityManager security = System.getSecurityManager();
+            SecurityManager sm = System.getSecurityManager();
             if (g == null) {
                 // the security manager can choose the thread group
-                if (security != null) {
-                    g = security.getThreadGroup();
+                if (sm != null) {
+                    g = sm.getThreadGroup();
                 }
 
                 // default to current thread's group
@@ -676,10 +676,10 @@ public class Thread implements Runnable {
             }
 
             // permission checks when creating a child Thread
-            if (security != null) {
-                security.checkAccess(g);
+            if (sm != null) {
+                sm.checkAccess(g);
                 if (isCCLOverridden(getClass())) {
-                    security.checkPermission(SecurityConstants.SUBCLASS_IMPLEMENTATION_PERMISSION);
+                    sm.checkPermission(SecurityConstants.SUBCLASS_IMPLEMENTATION_PERMISSION);
                 }
             }
 
@@ -687,15 +687,13 @@ public class Thread implements Runnable {
             this.holder = new FieldHolder(g, task, stackSize, priority, parent.isDaemon());
         }
 
-        // thread name and identifier
-        this.name = (name != null) ? name : genThreadName();
-        if (attaching && VM.initLevel() < 1) {
+        if (attached && VM.initLevel() < 1) {
             this.tid = 1;  // primordial thread
         } else {
             this.tid = ThreadIdentifiers.next();
         }
+        this.name = (name != null) ? name : genThreadName();
 
-        // ACC
         if (acc != null) {
             this.inheritedAccessControlContext = acc;
         } else {
@@ -703,7 +701,7 @@ public class Thread implements Runnable {
         }
 
         // thread locals
-        if (!attaching) {
+        if (!attached) {
             if ((characteristics & NO_THREAD_LOCALS) != 0) {
                 this.threadLocals = ThreadLocal.ThreadLocalMap.NOT_SUPPORTED;
                 this.inheritableThreadLocals = ThreadLocal.ThreadLocalMap.NOT_SUPPORTED;

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
@@ -1,0 +1,70 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287982
+ * @summary Test native threads attaching to the VM with JNI AttachCurrentThread
+ * @requires (os.family == "linux" | os.family == "mac")
+ * @library /test/lib
+ * @compile ExplicitAttach.java
+ * @run main AttachTest ExplicitAttach 1
+ * @run main AttachTest ExplicitAttach 2
+ * @run main AttachTest ExplicitAttach 4
+ */
+
+/**
+ * @test
+ * @summary Test native threads attaching implicitly to the VM by means of an upcall
+ * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
+ * @library /test/lib
+ * @compile --enable-preview -source ${jdk.version} ImplicitAttach.java
+ * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 1
+ * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 2
+ * @run main AttachTest --enable-preview --enable-native-access=ALL-UNNAMED ImplicitAttach 4
+ */
+
+import java.util.stream.Stream;
+import jdk.test.lib.process.ProcessTools;
+import jdk.test.lib.process.OutputAnalyzer;
+
+public class AttachTest {
+    static final String TEST_CLASSES = System.getProperty("test.classes");
+    static final String JAVA_LIBRARY_PATH = System.getProperty("java.library.path");
+
+    public static void main(String[] args) throws Exception {
+        // prepend -cp ${test.classes} -Djava.library.path=${java.library.path}
+        String[] opts = Stream.concat(Stream.of(
+                        "-cp", TEST_CLASSES,
+                        "-Djava.library.path=" + JAVA_LIBRARY_PATH),
+                        Stream.of(args))
+                .toArray(String[]::new);
+        OutputAnalyzer outputAnalyzer = ProcessTools
+                .executeTestJava(opts)
+                .outputTo(System.out)
+                .errorTo(System.out);
+        int exitValue = outputAnalyzer.getExitValue();
+        if (exitValue != 0)
+            throw new RuntimeException("Test failed");
+    }
+}

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ExplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ExplicitAttach.java
@@ -21,18 +21,11 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 8287982
- * @summary Test native threads attaching to the VM with JNI AttachCurrentThread
- * @requires (os.family == "linux" | os.family == "mac")
- * @run main/othervm ExplicitAttach 1
- * @run main/othervm ExplicitAttach 2
- * @run main/othervm ExplicitAttach 4
- */
-
 import java.util.concurrent.CountDownLatch;
 
+/**
+ * Test native threads attaching to the VM with JNI AttachCurrentThread.
+ */
 public class ExplicitAttach {
     private static volatile CountDownLatch latch;
 

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ExplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ExplicitAttach.java
@@ -1,0 +1,69 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287982
+ * @summary Test native threads attaching to the VM with JNI AttachCurrentThread
+ * @requires (os.family == "linux" | os.family == "mac")
+ * @run main/othervm ExplicitAttach 1
+ * @run main/othervm ExplicitAttach 2
+ * @run main/othervm ExplicitAttach 4
+ */
+
+import java.util.concurrent.CountDownLatch;
+
+public class ExplicitAttach {
+    private static volatile CountDownLatch latch;
+
+    public static void main(String[] args) throws Exception {
+        int threadCount;
+        if (args.length > 0) {
+            threadCount = Integer.parseInt(args[0]);
+        } else {
+            threadCount = 2;
+        }
+        latch = new CountDownLatch(threadCount);
+
+        // start the threads and wait for the threads to call home
+        startThreads(threadCount);
+        latch.await();
+    }
+
+    /**
+     * Invoked by attached threads.
+     */
+    private static void callback() {
+        System.out.println(Thread.currentThread());
+        latch.countDown();
+    }
+
+    /**
+     * Start n native threads that attach to the VM and invoke callback.
+     */
+    private static native void startThreads(int n);
+
+    static {
+        System.loadLibrary("ExplicitAttach");
+    }
+}

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -1,0 +1,87 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287982
+ * @summary Test native threads attaching implicitly the VM by means of an upcall
+ * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
+ * @enablePreview
+ * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 1
+ * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 2
+ * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 4
+ */
+
+import java.lang.foreign.*;
+import java.lang.invoke.MethodHandle;
+import java.lang.invoke.MethodHandles;
+import java.lang.invoke.MethodType;
+import java.util.concurrent.CountDownLatch;
+
+public class ImplicitAttach {
+    private static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT.withBitAlignment(32);
+    private static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);
+
+    private static volatile CountDownLatch latch;
+
+    public static void main(String[] args) throws Throwable {
+        int threadCount;
+        if (args.length > 0) {
+            threadCount = Integer.parseInt(args[0]);
+        } else {
+            threadCount = 2;
+        }
+        latch = new CountDownLatch(threadCount);
+
+        Linker abi = Linker.nativeLinker();
+
+        // stub to invoke callback
+        MethodHandle callback = MethodHandles.lookup()
+                .findStatic(ImplicitAttach.class, "callback", MethodType.methodType(void.class));
+        MemorySegment upcallStub = abi.upcallStub(callback,
+                FunctionDescriptor.ofVoid(),
+                MemorySession.openImplicit());
+
+        // void start_threads(int count, void *(*f)(void *))
+        SymbolLookup symbolLookup = SymbolLookup.loaderLookup();
+        MemorySegment symbol = symbolLookup.lookup("start_threads").orElseThrow();
+        FunctionDescriptor desc = FunctionDescriptor.ofVoid(C_INT, C_POINTER);
+        MethodHandle start_threads = abi.downcallHandle(symbol, desc);
+
+        // start the threads and wait for the threads to call home
+        start_threads.invoke(threadCount, upcallStub);
+        latch.await();
+    }
+
+    /**
+     * Invoked from native thread.
+     */
+    private static void callback() {
+        System.out.println(Thread.currentThread());
+        latch.countDown();
+    }
+
+    static {
+        System.loadLibrary("ImplicitAttach");
+    }
+}

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -21,23 +21,15 @@
  * questions.
  */
 
-/**
- * @test
- * @bug 8287982
- * @summary Test native threads attaching implicitly the VM by means of an upcall
- * @requires (os.family == "linux" | os.family == "mac") & (sun.arch.data.model == "64")
- * @enablePreview
- * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 1
- * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 2
- * @run main/othervm --enable-native-access=ALL-UNNAMED ImplicitAttach 4
- */
-
 import java.lang.foreign.*;
 import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.util.concurrent.CountDownLatch;
 
+/**
+ * Test native threads attaching implicitly to the VM by means of an upcall.
+ */
 public class ImplicitAttach {
     private static final ValueLayout.OfInt C_INT = ValueLayout.JAVA_INT.withBitAlignment(32);
     private static final ValueLayout.OfAddress C_POINTER = ValueLayout.ADDRESS.withBitAlignment(64);

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
@@ -22,7 +22,7 @@
  */
 #include <stdio.h>
 #include <pthread.h>
-#include <jni.h>
+#include "jni.h"
 
 #define STACK_SIZE 0x100000
 

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libExplicitAttach.c
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <stdio.h>
+#include <pthread.h>
+#include <jni.h>
+
+#define STACK_SIZE 0x100000
+
+/**
+ * Attach the current thread with JNI AttachCurrentThread, call a method, and detach.
+ */
+void* thread_main(void* arg) {
+    JavaVM *vm;
+    JNIEnv *env;
+    JavaVMInitArgs vm_args;
+    jsize count;
+    jint res;
+
+    res = JNI_GetCreatedJavaVMs(&vm, 1, &count);
+    if (res != JNI_OK) {
+        fprintf(stderr, "JNI_GetCreatedJavaVMs failed: %d\n", res);
+        return NULL;
+    }
+
+    res = (*vm)->AttachCurrentThread(vm, (void **) &env, NULL);
+    if (res != JNI_OK) {
+        fprintf(stderr, "AttachCurrentThreadAsDaemon failed: %d\n", res);
+        return NULL;
+    }
+
+    // call ExplicitAttach.callback()
+    jclass clazz = (*env)->FindClass(env, "ExplicitAttach");
+    if (clazz == NULL) {
+        fprintf(stderr, "FindClass failed\n");
+        goto detach;
+    }
+    jmethodID mid = (*env)->GetStaticMethodID(env, clazz, "callback", "()V");
+    if (mid == NULL) {
+        fprintf(stderr, "GetStaticMethodID failed\n");
+        goto detach;
+    }
+    (*env)->CallStaticVoidMethod(env, clazz, mid);
+    if ((*env)->ExceptionOccurred(env)) {
+        fprintf(stderr, "CallStaticVoidMethod failed\n");
+        goto detach;
+    }
+
+  detach:
+    res = (*vm)->DetachCurrentThread(vm);
+    if (res != JNI_OK) {
+        fprintf(stderr, "DetachCurrentThread failed: %d\n", res);
+    }
+
+    return NULL;
+}
+
+JNIEXPORT void JNICALL Java_ExplicitAttach_startThreads(JNIEnv *env, jclass clazz, int n) {
+    pthread_t tid;
+    pthread_attr_t attr;
+    int i;
+
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, STACK_SIZE);
+    for (i = 0; i < n ; i++) {
+        int res = pthread_create(&tid, &attr, thread_main, NULL);
+        if (res != 0) {
+            fprintf(stderr, "pthread_create failed: %d\n", res);
+        }
+    }
+}

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libImplicitAttach.c
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/libImplicitAttach.c
@@ -1,0 +1,44 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+#include <stdio.h>
+#include <pthread.h>
+
+#define STACK_SIZE 0x100000
+
+/**
+ * Creates n threads to execute the given function.
+ */
+void start_threads(int n, void *(*f)(void *)) {
+    pthread_t tid;
+    pthread_attr_t attr;
+    int i;
+
+    pthread_attr_init(&attr);
+    pthread_attr_setstacksize(&attr, STACK_SIZE);
+    for (i = 0; i < n ; i++) {
+        int res = pthread_create(&tid, &attr, f, NULL);
+        if (res != 0) {
+            fprintf(stderr, "pthread_create failed: %d\n", res);
+        }
+    }
+}


### PR DESCRIPTION
If several native threads attach to the VM at around the same time, and before any threads get an automatically generated name are created, then the VM may crash attempting to access the thread status. The issue exists for native threads that attach explicitly with JNI AttachCurrentThread without a thread name, or native threads that attach implicitly by using a function pointer to do an up call.

The issue that raises its head periodically is that native threads that JNI attach do the initializaiton of the Thread object in the context of the attaching thread. Great care must be taken because Java code is executing in the context of a Thread that is not fully initialized. The right thing is probably to create the Thread object in another thread, using the service thread has been mentioned. The issue at this time arises when two or more native threads attempt to attach without thread names at around the same time. The first thread that needs an automatically generated name triggers the loading and initialization of a helper class.  If there are other threads attaching at the same time then they may have to wait on the monitor which can trigger the crash because the field holder with the thread status is not created at this time. Crashes in monitor enter and notify have been observed. Coleen has changed this code so that linking and initialization uses a mutex (JDK-8288064) so this specific crash doesn't duplicate in the main line. The short term fix for openjdk/jdk19 is to reorder the initialization so that field holder with the thread status is created before setting the name.

Creating a jtreg test with the conditions to duplicate this issue is complicated. The jtreg main wrapper creates the main thread with an automatically generated thread name before it runs the test main method. This is the reason that the test needs to launch a new VM with the right setup to exercise both explicit and implicit attach.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287982](https://bugs.openjdk.org/browse/JDK-8287982): Concurrent implicit attach from native threads crashes VM


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/28/head:pull/28` \
`$ git checkout pull/28`

Update a local copy of the PR: \
`$ git checkout pull/28` \
`$ git pull https://git.openjdk.org/jdk19 pull/28/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 28`

View PR using the GUI difftool: \
`$ git pr show -t 28`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/28.diff">https://git.openjdk.org/jdk19/pull/28.diff</a>

</details>
