### PR TITLE
8288564: C2: LShiftLNode::Ideal produces wrong result after JDK-8278114

### DIFF
--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -813,7 +813,8 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // Left input is an add of the same number?
       if (add1->in(1) == add1->in(2)) {
         // Convert "(x + x) << c0" into "x << (c0 + 1)"
-        assert(con != BitsPerJavaInteger - 1, "sanity check, optimization cannot be applied for con == 31");
+        // In general, this optimization cannot be applied for c0 == 31 since
+        // 2x << 31 != x << 32 = x << 0 = x (e.g. x = 1: 2 < 31 = 0 != 1)
         return new LShiftINode(add1->in(1), phase->intcon(con + 1));
       }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -814,7 +814,7 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       if (add1->in(1) == add1->in(2)) {
         // Convert "(x + x) << c0" into "x << (c0 + 1)"
         // In general, this optimization cannot be applied for c0 == 31 since
-        // 2x << 31 != x << 32 = x << 0 = x (e.g. x = 1: 2 < 31 = 0 != 1)
+        // 2x << 31 != x << 32 = x << 0 = x (e.g. x = 1: 2 << 31 = 0 != 1)
         return new LShiftINode(add1->in(1), phase->intcon(con + 1));
       }
 

--- a/src/hotspot/share/opto/mulnode.cpp
+++ b/src/hotspot/share/opto/mulnode.cpp
@@ -813,6 +813,7 @@ Node *LShiftINode::Ideal(PhaseGVN *phase, bool can_reshape) {
       // Left input is an add of the same number?
       if (add1->in(1) == add1->in(2)) {
         // Convert "(x + x) << c0" into "x << (c0 + 1)"
+        assert(con != BitsPerJavaInteger - 1, "sanity check, optimization cannot be applied for con == 31");
         return new LShiftINode(add1->in(1), phase->intcon(con + 1));
       }
 
@@ -930,8 +931,13 @@ Node *LShiftLNode::Ideal(PhaseGVN *phase, bool can_reshape) {
     assert( add1 != add1->in(1), "dead loop in LShiftLNode::Ideal" );
 
     // Left input is an add of the same number?
-    if (add1->in(1) == add1->in(2)) {
+    if (con != (BitsPerJavaLong - 1) && add1->in(1) == add1->in(2)) {
       // Convert "(x + x) << c0" into "x << (c0 + 1)"
+      // Can only be applied if c0 != 63 because:
+      // (x + x) << 63 = 2x << 63, while
+      // (x + x) << 63 --transform--> x << 64 = x << 0 = x (!= 2x << 63, for example for x = 1)
+      // According to the Java spec, chapter 15.19, we only consider the six lowest-order bits of the right-hand operand
+      // (i.e. "right-hand operand" & 0b111111). Therefore, x << 64 is the same as x << 0 (64 = 0b10000000 & 0b0111111 = 0).
       return new LShiftLNode(add1->in(1), phase->intcon(con + 1));
     }
 

--- a/test/hotspot/jtreg/compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java
+++ b/test/hotspot/jtreg/compiler/c2/irTests/TestIRLShiftIdeal_XPlusX_LShiftC.java
@@ -28,7 +28,7 @@ import compiler.lib.ir_framework.*;
 
 /*
  * @test
- * @bug 8278114
+ * @bug 8278114 8288564
  * @summary Test that transformation from (x + x) >> c to x >> (c + 1) works as intended.
  * @library /test/lib /
  * @requires vm.compiler2.enabled
@@ -148,5 +148,35 @@ public class TestIRLShiftIdeal_XPlusX_LShiftC {
             // C2 compilation happens
             Asserts.assertTrue(info.isTestC2Compiled());
         }
+    }
+
+    @Test
+    @IR(failOn = {IRNode.MUL_I})
+    @IR(counts = {IRNode.LSHIFT_I, "1",
+                  IRNode.ADD_I, "1"})
+    public int testIntRandom(int x) {
+        return (x + x) << 31;
+    }
+
+    @Run(test = "testIntRandom")
+    public void runTestIntRandom() {
+        int random = RunInfo.getRandom().nextInt();
+        int interpreterResult = (random + random) << 31;
+        Asserts.assertEQ(testIntRandom(random), interpreterResult);
+    }
+
+    @Test
+    @IR(failOn = {IRNode.MUL_L})
+    @IR(counts = {IRNode.LSHIFT_L, "1",
+                  IRNode.ADD_L, "1"})
+    public long testLongRandom(long x) {
+        return (x + x) << 63;
+    }
+
+    @Run(test = "testLongRandom")
+    public void runTestLongRandom() {
+        long random = RunInfo.getRandom().nextLong();
+        long interpreterResult = (random + random) << 63;
+        Asserts.assertEQ(testLongRandom(random), interpreterResult);
     }
 }


### PR DESCRIPTION
[JDK-8278114](https://bugs.openjdk.org/browse/JDK-8278114) added the following transformation for integer and long left shifts:
```
 "(x + x) << c0" into "x << (c0 + 1)"
```
However, in the long shift case, this transformation is not correct if `c0` is 63:

```
(x + x) << 63 = 2x << 63
```
while
```
 (x + x) << 63 --transform--> x << 64 = x << 0 = x
```
which is not the same. For example, if `x = 1`:
```
2x << 63 = 2 << 63 = 0 != 1
```
This optimization does not account for the fact that `x << 64` is the same as `x << 0 = x`. According to the [Java spec, chapter 15.19](https://docs.oracle.com/javase/specs/jls/se18/html/jls-15.html#jls-15.19), we only consider the six lowest-order bits of the right-hand operand (i.e. `"right-hand operand" & 0b111111`). Therefore, `x << 64` is the same as `x << 0` (`64 = 0b10000000 & 0b0111111 = 0`).

Integer shifts are not affected because we do not apply this transformation if `c0 >= 16`:

https://github.com/openjdk/jdk19/blob/729164f53499f146579a48ba1b466c687802f330/src/hotspot/share/opto/mulnode.cpp#L810-L817

The fix I propose is to not apply this optimization for long left shifts if `c0 == 63`. I've added an additional sanity assertion for integer left shifts just in case this optimization is moved at some point and ending up outside the check for `con < 16`.

Thanks,
Christian

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288564](https://bugs.openjdk.org/browse/JDK-8288564): C2: LShiftLNode::Ideal produces wrong result after JDK-8278114


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to [37040f94](https://git.openjdk.org/jdk19/pull/29/files/37040f94ee641781733c603c49d6814707d66e92)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/29/head:pull/29` \
`$ git checkout pull/29`

Update a local copy of the PR: \
`$ git checkout pull/29` \
`$ git pull https://git.openjdk.org/jdk19 pull/29/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 29`

View PR using the GUI difftool: \
`$ git pr show -t 29`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/29.diff">https://git.openjdk.org/jdk19/pull/29.diff</a>

</details>
