### PR TITLE
JDK-8288545: Missing space in error message

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -978,11 +978,15 @@ public class HtmlDocletWriter {
         String tagName = ch.getTagName(see);
 
         String seeText = utils.normalizeNewlines(ch.getText(see)).toString();
+        String refText;
         List<? extends DocTree> label;
         switch (kind) {
-            case LINK, LINK_PLAIN ->
+            case LINK, LINK_PLAIN -> {
                 // {@link[plain] reference label...}
-                label = ((LinkTree) see).getLabel();
+                LinkTree lt = (LinkTree) see;
+                refText = lt.getReference().toString();
+                label = lt.getLabel();
+            }
 
             case SEE -> {
                 List<? extends DocTree> ref = ((SeeTree) see).getReference();
@@ -998,6 +1002,7 @@ public class HtmlDocletWriter {
                     }
                     case REFERENCE -> {
                         // @see reference label...
+                        refText = ref.get(0).toString();
                         label = ref.subList(1, ref.size());
                     }
                     case ERRONEOUS -> {
@@ -1058,7 +1063,7 @@ public class HtmlDocletWriter {
                         messages.warning(ch.getDocTreePath(see),
                                 "doclet.see.class_or_package_not_found",
                                 "@" + tagName,
-                                seeText);
+                                refText);
                     }
                     return invalidTagOutput(resources.getText("doclet.tag.invalid", tagName),
                             Optional.of(labelContent.isEmpty() ? text: labelContent));
@@ -1112,7 +1117,7 @@ public class HtmlDocletWriter {
                     if (!configuration.isDocLintReferenceGroupEnabled()) {
                         messages.warning(
                                 ch.getDocTreePath(see), "doclet.see.class_or_package_not_found",
-                                tagName, seeText);
+                                tagName, refText);
                     }
                 }
             }

--- a/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkNotFound.java
+++ b/test/langtools/jdk/javadoc/doclet/testLinkTaglet/TestLinkNotFound.java
@@ -1,0 +1,71 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug      8288545
+ * @summary  Missing space in error message
+ * @library  /tools/lib ../../lib
+ * @modules  jdk.javadoc/jdk.javadoc.internal.tool
+ * @build    toolbox.ToolBox javadoc.tester.*
+ * @run main TestLinkNotFound
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+
+public class TestLinkNotFound extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        TestLinkNotFound tester = new TestLinkNotFound();
+        tester.runTests();
+    }
+
+    ToolBox tb = new ToolBox();
+
+    @Test
+    public void test(Path base) throws Exception {
+        Path src = base.resolve("src");
+        tb.writeJavaFiles(src,
+                """
+                    /**
+                     * Comment.
+                     * {@link nowhere label}
+                     */
+                    public class C{ }
+                    """);
+
+        javadoc("-d", base.resolve("api").toString(),
+                "-Xdoclint:none",
+                "-Werror",
+                "-sourcepath", src.toString(),
+                src.resolve("C.java").toString());
+        checkExit(Exit.ERROR);
+
+        // the use of '\n' in the following check implies that the label does not appear after the reference
+        checkOutput(Output.OUT, true,
+                "reference not found: nowhere\n");
+    }
+}


### PR DESCRIPTION
Please review a minor update to fix the content of an error message.

As reported in JBS, the problem was partly that there was a missing space to separate two items, but also, the second item should not have been there anyway.

The fix here, for 19, is to suppress the second item.    Fixing the missing space will be part of a follow-up cleanup in mainline, that is too big to include here.

Note: there is no attempt in this fix to address whether the message should be generated at all.