### PR TITLE
8268398: 15% increase in JFR footprint in Noop-Base

### DIFF
--- a/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.cpp
@@ -61,6 +61,10 @@
 #include "runtime/thread.hpp"
 #include "utilities/debug.hpp"
 
+#ifdef LINUX
+#include "osContainer_linux.hpp"
+#endif
+
 #define NO_TRANSITION(result_type, header) extern "C" { result_type JNICALL header {
 #define NO_TRANSITION_END } }
 
@@ -380,4 +384,12 @@ JVM_END
 
 JVM_ENTRY_NO_ENV(jboolean, jfr_is_class_instrumented(JNIEnv* env, jobject jvm, jclass clazz))
   return JfrJavaSupport::is_instrumented(clazz, thread);
+JVM_END
+
+JVM_ENTRY_NO_ENV(jboolean, jfr_is_containerized(JNIEnv* env, jobject jvm))
+#ifdef LINUX
+  return OSContainer::is_containerized();
+#else
+  return false;
+#endif
 JVM_END

--- a/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethod.hpp
@@ -158,9 +158,10 @@ jboolean JNICALL jfr_is_class_excluded(JNIEnv* env, jobject jvm, jclass clazz);
 
 jboolean JNICALL jfr_is_class_instrumented(JNIEnv* env, jobject jvm, jclass clazz);
 
+jboolean JNICALL jfr_is_containerized(JNIEnv* env, jobject jvm);
+
 #ifdef __cplusplus
 }
 #endif
 
 #endif // SHARE_JFR_JNI_JFRJNIMETHOD_HPP
-

--- a/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
+++ b/src/hotspot/share/jfr/jni/jfrJniMethodRegistration.cpp
@@ -93,7 +93,8 @@ JfrJniMethodRegistration::JfrJniMethodRegistration(JNIEnv* env) {
       (char*)"setConfiguration", (char*)"(Ljava/lang/Class;Ljdk/jfr/internal/event/EventConfiguration;)Z", (void*)jfr_set_configuration,
       (char*)"getTypeId", (char*)"(Ljava/lang/String;)J", (void*)jfr_get_type_id_from_string,
       (char*)"isExcluded", (char*)"(Ljava/lang/Class;)Z", (void*)jfr_is_class_excluded,
-      (char*)"isInstrumented", (char*)"(Ljava/lang/Class;)Z", (void*) jfr_is_class_instrumented
+      (char*)"isInstrumented", (char*)"(Ljava/lang/Class;)Z", (void*) jfr_is_class_instrumented,
+      (char*)"isContainerized", (char*)"()Z", (void*) jfr_is_containerized
     };
 
     const size_t method_array_length = sizeof(method) / sizeof(JNINativeMethod);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/JVM.java
@@ -620,4 +620,13 @@ public final class JVM {
      * @return the id, or a negative value if it does not exists.
      */
     public native long getTypeId(String name);
+
+    /**
+     * Returns {@code true}, if the JVM is running in a container, {@code false} otherwise.
+     * <p>
+     * If -XX:-UseContainerSupport has been specified, this method returns {@code false},
+     * which is questionable, but Container.metrics() returns {@code null}, so events
+     * can't be emitted anyway.
+     */
+    public native boolean isContainerized();
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -218,6 +218,7 @@ public final class MetadataRepository {
         EventConfiguration configuration = newEventConfiguration(eventType, ec, settings);
         PlatformEventType pe = configuration.getPlatformEventType();
         pe.setRegistered(true);
+        // If class is instrumented or should not be instrumented, mark as instrumented.
         if (jvm.isInstrumented(eventClass) || !Utils.shouldInstrument(pe.isJDK(), pe.getName())) {
             pe.setInstrumented();
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/MetadataRepository.java
@@ -218,7 +218,7 @@ public final class MetadataRepository {
         EventConfiguration configuration = newEventConfiguration(eventType, ec, settings);
         PlatformEventType pe = configuration.getPlatformEventType();
         pe.setRegistered(true);
-        if (jvm.isInstrumented(eventClass)) {
+        if (jvm.isInstrumented(eventClass) || !Utils.shouldInstrument(pe.isJDK(), pe.getName())) {
             pe.setInstrumented();
         }
         Utils.setConfiguration(eventClass, configuration);

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -702,7 +702,7 @@ public final class Utils {
             return true;
         }
         if (!name.contains(".Container")) {
-            // Matched @Name("jdk.jfr.Container*") or class name jdk.jfr.events.Container*
+            // Didn't match @Name("jdk.jfr.Container*") or class name "jdk.jfr.events.Container*"
             return true;
         }
         return JVM.getJVM().isContainerized();

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/Utils.java
@@ -94,7 +94,6 @@ public final class Utils {
      * This field will be lazily initialized and the access is not synchronized.
      * The possible data race is benign and is worth of not introducing any contention here.
      */
-    private static Metrics[] metrics;
     private static Instant lastTimestamp;
 
     public static void checkAccessFlightRecorder() throws SecurityException {
@@ -698,18 +697,15 @@ public final class Utils {
         }
     }
 
-    public static boolean shouldSkipBytecode(String eventName, Class<?> superClass) {
-        if (superClass.getClassLoader() != null || !superClass.getName().equals("jdk.jfr.events.AbstractJDKEvent")) {
-            return false;
+    public static boolean shouldInstrument(boolean isJDK, String name) {
+        if (!isJDK) {
+            return true;
         }
-        return eventName.startsWith("jdk.Container") && getMetrics() == null;
-    }
-
-    private static Metrics getMetrics() {
-        if (metrics == null) {
-            metrics = new Metrics[]{Metrics.systemMetrics()};
+        if (!name.contains(".Container")) {
+            // Matched @Name("jdk.jfr.Container*") or class name jdk.jfr.events.Container*
+            return true;
         }
-        return metrics[0];
+        return JVM.getJVM().isContainerized();
     }
 
     private static String formatPositiveDuration(Duration d){

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/instrument/JDKEvents.java
@@ -174,7 +174,15 @@ public final class JDKEvents {
     }
 
     private static void initializeContainerEvents() {
-        containerMetrics = Container.metrics();
+        if (JVM.getJVM().isContainerized() ) {
+            Logger.log(LogTag.JFR_SYSTEM, LogLevel.DEBUG, "JVM is containerized");
+            containerMetrics = Container.metrics();
+            if (containerMetrics != null) {
+                Logger.log(LogTag.JFR_SYSTEM, LogLevel.DEBUG, "Container metrics are available");
+            }
+        }
+        // The registration of events and hooks are needed to provide metadata,
+        // even when not running in a container
         SecuritySupport.registerEvent(ContainerConfigurationEvent.class);
         SecuritySupport.registerEvent(ContainerCPUUsageEvent.class);
         SecuritySupport.registerEvent(ContainerCPUThrottlingEvent.class);


### PR DESCRIPTION
Hi,

Could I have a review of a PR that skips bytecode instrumentation for container events and initialisation of Container.metrics() if the JVM isn't running in a container, or to be precise, if container support is not available. If a user specifies -XX:-UseContainerSupport, events are not emitted. This was the case before this PR, and maybe it should be fixed, but it's an enhancement and outside the scope of this bug.

Testing:
- jdk/jdk/jfr
- Manual testing in a container.

I tried to run test/hotspot/jtreg/containers/docker/TestJFREvents.java, but the test is broken (image can't be built, so test is skipped). 

This fix may not be sufficient to reduce footprint introduced by the container events, but [JDK-8282420: JFR: Remove event handlers](https://bugs.openjdk.org/browse/JDK-8282420) also reduced number of loaded classes which should reduce footprint in JDK 19. There are an ongoing enhancement work to generate bytecode and metadata at build time, which will help, but it will be integrated in JDK 20. 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8268398](https://bugs.openjdk.org/browse/JDK-8268398): 15% increase in JFR footprint in Noop-Base


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/31/head:pull/31` \
`$ git checkout pull/31`

Update a local copy of the PR: \
`$ git checkout pull/31` \
`$ git pull https://git.openjdk.org/jdk19 pull/31/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 31`

View PR using the GUI difftool: \
`$ git pr show -t 31`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/31.diff">https://git.openjdk.org/jdk19/pull/31.diff</a>

</details>
