### PR TITLE
8288467: remove memory_operand assert for spilled instructions

### DIFF
--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -1732,8 +1732,13 @@ void PhaseChaitin::fixup_spills() {
             // instructions which have "stackSlotX" parameter instead of "memory".
             // For example, "MoveF2I_stack_reg". We always need a memory edge from
             // src to cisc, else we might schedule cisc before src, loading from a
-            // spill location before storing the spill.
-            assert(cisc->memory_operand() == nullptr, "no memory operand, only stack");
+            // spill location before storing the spill. On some platforms, we land
+            // in this else case because mach->oper_input_base() > 1, i.e. we have
+            // multiple inputs. In some rare cases there are even multiple memory
+            // operands, before and after spilling.
+            // (e.g. spilling "addFPR24_reg_mem" to "addFPR24_mem_cisc")
+            // In eigher case, there is no space in the inputs for the memory edge
+            // so we add an additional precedence / memory edge.
             cisc->add_prec(src);
           }
           block->map_node(cisc, j);          // Insert into basic block

--- a/src/hotspot/share/opto/chaitin.cpp
+++ b/src/hotspot/share/opto/chaitin.cpp
@@ -1737,7 +1737,7 @@ void PhaseChaitin::fixup_spills() {
             // multiple inputs. In some rare cases there are even multiple memory
             // operands, before and after spilling.
             // (e.g. spilling "addFPR24_reg_mem" to "addFPR24_mem_cisc")
-            // In eigher case, there is no space in the inputs for the memory edge
+            // In either case, there is no space in the inputs for the memory edge
             // so we add an additional precedence / memory edge.
             cisc->add_prec(src);
           }


### PR DESCRIPTION
In [JDK-8282555](https://bugs.openjdk.org/browse/JDK-8282555) I added this assert, because on x64 this seems to always hold. But it turns out there are instructions on x86 (32bit) that violate this assumption.

**Why it holds on x64**
It seems we only ever do one read or one write per instruction. Instructions with multiple memory operands are extremely rare.
1. we spill from register to memory: we land in the if case, where the cisc node has an additional input slot for the memory edge.
2. we spill from register to stackSlot: no additional input slot is reserved, we land in else case and add an additional precedence edge.

**Why it is violated on x86 (32bit)**
We have additional cases that land in the else case. For example spilling `src1` from `addFPR24_reg_mem` to `addFPR24_mem_cisc`.
https://github.com/openjdk/jdk19/blob/53bf1bfdabb79b37afedd09051d057f9eea620f2/src/hotspot/cpu/x86/x86_32.ad#L10325-L10327 https://github.com/openjdk/jdk19/blob/53bf1bfdabb79b37afedd09051d057f9eea620f2/src/hotspot/cpu/x86/x86_32.ad#L10368-L10370
We land in the else case, because both have 2 inputs, thus `oper_input_base() == 2`.
And both have memory operands, so the assert must fail.

**Solutions**
1. Remove the Assert, as it is incorrect.
2. Extend the assert to be correct.
   - case 1: reg to mem spill, where we have a reserved input slot in cisc for memory edge
   - case 2: reg to stackSlot spill, where both mach and cisc have no memory operand.
   - other cases, with various register, stackSlot and memory inputs and outputs. We would have to find a general rule, and test it properly, which is not trivial because getting registers to spill is not easy to precisely provoke.
3. Have platform dependent asserts. But also this makes testing harder.

For now I went with 1. as it is simple and as far as I can see correct.

Running tests on x64 (should not fail). **I need someone to help me with testing x86 (32bit)**. I only verified the reported test failure with a 32bit build.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288467](https://bugs.openjdk.org/browse/JDK-8288467): remove memory_operand assert for spilled instructions


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [d082aa91](https://git.openjdk.org/jdk19/pull/33/files/d082aa913256e1ed586b6d0271a043b66365e3d1)
 * [Aleksey Shipilev](https://openjdk.org/census#shade) (@shipilev - **Reviewer**)
 * [Jatin Bhateja](https://openjdk.org/census#jbhateja) (@jatin-bhateja - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/33/head:pull/33` \
`$ git checkout pull/33`

Update a local copy of the PR: \
`$ git checkout pull/33` \
`$ git pull https://git.openjdk.org/jdk19 pull/33/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 33`

View PR using the GUI difftool: \
`$ git pr show -t 33`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/33.diff">https://git.openjdk.org/jdk19/pull/33.diff</a>

</details>
