### PR TITLE
8288120: VerifyError with JEP 405 pattern match

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/TransPatterns.java
@@ -347,9 +347,6 @@ public class TransPatterns extends TreeTranslator {
 
     private MethodSymbol getAccessor(DiagnosticPosition pos, RecordComponent component) {
         return component2Proxy.computeIfAbsent(component, c -> {
-            MethodSymbol realAccessor =
-                    rs.resolveInternalMethod(pos, env, component.owner.type,
-                                             component.name, List.nil(), List.nil());
             MethodType type = new MethodType(List.of(component.owner.erasure(types)),
                                              types.erasure(component.type),
                                              List.nil(),
@@ -359,7 +356,7 @@ public class TransPatterns extends TreeTranslator {
                                                   type,
                                                   currentClass);
             JCStatement accessorStatement =
-                    make.Return(make.App(make.Select(make.Ident(proxy.params().head), realAccessor)));
+                    make.Return(make.App(make.Select(make.Ident(proxy.params().head), c.accessor)));
             VarSymbol ctch = new VarSymbol(Flags.SYNTHETIC,
                     names.fromString("catch" + currentClassTree.pos + target.syntheticNameChar()),
                     syms.throwableType,

--- a/test/langtools/tools/javac/patterns/ProxyMethodLookup.java
+++ b/test/langtools/tools/javac/patterns/ProxyMethodLookup.java
@@ -1,0 +1,47 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8288120
+ * @summary Verify an appropriate accessor method is looked up.
+ * @compile --enable-preview -source ${jdk.version} ProxyMethodLookup.java
+ * @run main/othervm --enable-preview ProxyMethodLookup
+ */
+public class ProxyMethodLookup {
+
+    public static void main(String[] args) {
+        Object val = new R(new Component());
+        boolean b = val instanceof R(var c);
+   }
+
+    interface ComponentBase {}
+
+    record Component() implements ComponentBase {}
+
+    sealed interface Base {
+        ComponentBase c();
+    }
+
+    record R(Component c) implements Base {}
+}


### PR DESCRIPTION
When pattern matching is looking up the accessor methods, it currently uses `Scope.findFirst`. This method may find a method with the same name from the record's supertype. The proposal is to use `Resolve.resolveInternalMethod` which should lookup the methods based on the ordinary rules, and should find the accessor from the record.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288120](https://bugs.openjdk.org/browse/JDK-8288120): VerifyError with JEP 405 pattern match


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/34/head:pull/34` \
`$ git checkout pull/34`

Update a local copy of the PR: \
`$ git checkout pull/34` \
`$ git pull https://git.openjdk.org/jdk19 pull/34/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 34`

View PR using the GUI difftool: \
`$ git pr show -t 34`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/34.diff">https://git.openjdk.org/jdk19/pull/34.diff</a>

</details>
