### PR TITLE
8288527: broken link in java.base/java/util/zip/package-summary.html

### DIFF
--- a/src/java.base/share/classes/java/util/zip/package-info.java
+++ b/src/java.base/share/classes/java/util/zip/package-info.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2017, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -39,12 +39,12 @@
  *         are based.
  *     <li><a id="zip64">An implementation may optionally support the
  *         ZIP64(tm) format extensions defined by the</a>
- *         <a href="http://www.pkware.com/documents/casestudies/APPNOTE.TXT">
+ *         <a href="https://support.pkware.com/home/pkzip/developer-tools/appnote">
  *         PKWARE ZIP File Format Specification</a>. The ZIP64(tm) format
  *         extensions are used to overcome the size limitations of the
  *         original ZIP format.
  *     <li><a id="lang_encoding">APPENDIX D of</a>
- *         <a href="http://www.pkware.com/documents/casestudies/APPNOTE.TXT">
+ *         <a href="https://support.pkware.com/home/pkzip/developer-tools/appnote">
  *         PKWARE ZIP File Format Specification</a> - Language Encoding Flag
  *         to encode ZIP entry filename and comment fields using UTF-8.
  *     <li><a href="http://www.ietf.org/rfc/rfc1950.txt">


### PR DESCRIPTION
Hi all,

Please review this patch for JDK 19 to address a broken link due to PKWare moving the location for APPNOTE.txt

Best,
Lance

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288527](https://bugs.openjdk.org/browse/JDK-8288527): broken link in java.base/java/util/zip/package-summary.html


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Martin Buchholz](https://openjdk.org/census#martin) (@Martin-Buchholz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/35/head:pull/35` \
`$ git checkout pull/35`

Update a local copy of the PR: \
`$ git checkout pull/35` \
`$ git pull https://git.openjdk.org/jdk19 pull/35/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 35`

View PR using the GUI difftool: \
`$ git pr show -t 35`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/35.diff">https://git.openjdk.org/jdk19/pull/35.diff</a>

</details>
