### PR TITLE
8288596: Random:from() adapter does not delegate to supplied generator in all cases

### DIFF
--- a/src/java.base/share/classes/java/util/Random.java
+++ b/src/java.base/share/classes/java/util/Random.java
@@ -130,6 +130,11 @@ public class Random implements RandomGenerator, java.io.Serializable {
         }
 
         @Override
+        public boolean isDeprecated() {
+            return generator.isDeprecated();
+        }
+
+        @Override
         public void nextBytes(byte[] bytes) {
             this.generator.nextBytes(bytes);
         }
@@ -145,8 +150,23 @@ public class Random implements RandomGenerator, java.io.Serializable {
         }
 
         @Override
+        public int nextInt(int origin, int bound) {
+            return generator.nextInt(origin, bound);
+        }
+
+        @Override
         public long nextLong() {
             return this.generator.nextLong();
+        }
+
+        @Override
+        public long nextLong(long bound) {
+            return generator.nextLong(bound);
+        }
+
+        @Override
+        public long nextLong(long origin, long bound) {
+            return generator.nextLong(origin, bound);
         }
 
         @Override
@@ -160,13 +180,43 @@ public class Random implements RandomGenerator, java.io.Serializable {
         }
 
         @Override
+        public float nextFloat(float bound) {
+            return generator.nextFloat(bound);
+        }
+
+        @Override
+        public float nextFloat(float origin, float bound) {
+            return generator.nextFloat(origin, bound);
+        }
+
+        @Override
         public double nextDouble() {
             return this.generator.nextDouble();
         }
 
         @Override
+        public double nextDouble(double bound) {
+            return generator.nextDouble(bound);
+        }
+
+        @Override
+        public double nextDouble(double origin, double bound) {
+            return generator.nextDouble(origin, bound);
+        }
+
+        @Override
+        public double nextExponential() {
+            return generator.nextExponential();
+        }
+
+        @Override
         public double nextGaussian() {
             return this.generator.nextGaussian();
+        }
+
+        @Override
+        public double nextGaussian(double mean, double stddev) {
+            return generator.nextGaussian(mean, stddev);
         }
 
         @Override
@@ -1066,7 +1116,7 @@ public class Random implements RandomGenerator, java.io.Serializable {
         return AbstractSpliteratorGenerator.doubles(this);
     }
 
-   /**
+    /**
      * Returns a stream producing the given {@code streamSize} number of
      * pseudorandom {@code double} values, each conforming to the given origin
      * (inclusive) and bound (exclusive).
@@ -1076,7 +1126,7 @@ public class Random implements RandomGenerator, java.io.Serializable {
      * @param randomNumberBound the bound (exclusive) of each random value
      * @return a stream of pseudorandom {@code double} values,
      *         each with the given origin (inclusive) and bound (exclusive)
-    * @throws IllegalArgumentException {@inheritDoc}
+     * @throws IllegalArgumentException {@inheritDoc}
      * @since 1.8
      */
     @Override


### PR DESCRIPTION
Extend delegation by instance returned by Random.from() to all methods exposed by RandomGenerator.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288596](https://bugs.openjdk.org/browse/JDK-8288596): Random:from() adapter does not delegate to supplied generator in all cases


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/36/head:pull/36` \
`$ git checkout pull/36`

Update a local copy of the PR: \
`$ git checkout pull/36` \
`$ git pull https://git.openjdk.org/jdk19 pull/36/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 36`

View PR using the GUI difftool: \
`$ git pr show -t 36`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/36.diff">https://git.openjdk.org/jdk19/pull/36.diff</a>

</details>
