### PR TITLE
JDK-8288692: jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java fails after JDK-8288545

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/HtmlDocletWriter.java
@@ -984,7 +984,13 @@ public class HtmlDocletWriter {
             case LINK, LINK_PLAIN -> {
                 // {@link[plain] reference label...}
                 LinkTree lt = (LinkTree) see;
-                refText = lt.getReference().toString();
+                var linkRef = lt.getReference();
+                if (linkRef == null) {
+                    messages.warning(ch.getDocTreePath(see),"doclet.link.no_reference");
+                    return invalidTagOutput(resources.getText("doclet.tag.invalid_input", lt.toString()),
+                        Optional.empty());
+                }
+                refText = linkRef.toString();
                 label = lt.getLabel();
             }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/resources/standard.properties
@@ -102,6 +102,7 @@ doclet.MalformedURL=Malformed URL: {0}
 doclet.File_error=Error reading file: {0}
 doclet.URL_error=Error fetching URL: {0}
 doclet.Resource_error=Error reading resource: {0}
+doclet.link.no_reference=no reference given
 doclet.see.class_or_package_not_found=Tag {0}: reference not found: {1}
 doclet.see.class_or_package_not_accessible=Tag {0}: reference not accessible: {1}
 doclet.see.nested_link=Tag {0}: nested link

--- a/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2001, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2001, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
+++ b/test/langtools/jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java
@@ -23,6 +23,7 @@
 
 /*
  * @test
+ * @bug 8035473 8288692
  * @summary Determine if proper warning messages are printed.
  * @library ../../lib
  * @modules jdk.javadoc/jdk.javadoc.internal.tool


### PR DESCRIPTION
Please review a simple fix to address an NPE that can occur with a bad (empty) `{@link}` tag.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288692](https://bugs.openjdk.org/browse/JDK-8288692): jdk/javadoc/doclet/testTagMisuse/TestTagMisuse.java fails after JDK-8288545


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**) ⚠️ Review applies to [bfda2d52](https://git.openjdk.org/jdk19/pull/37/files/bfda2d526b3187cdbbdebeb02def850f1e56178c)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/37/head:pull/37` \
`$ git checkout pull/37`

Update a local copy of the PR: \
`$ git checkout pull/37` \
`$ git pull https://git.openjdk.org/jdk19 pull/37/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 37`

View PR using the GUI difftool: \
`$ git pr show -t 37`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/37.diff">https://git.openjdk.org/jdk19/pull/37.diff</a>

</details>
