### PR TITLE
8280320: C2: Loop opts are missing during OSR compilation

### DIFF
--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -249,10 +249,14 @@ bool ciMethodData::load_data() {
   // Note:  Extra data are all BitData, and do not need translation.
   _invocation_counter = mdo->invocation_count();
   if (_invocation_counter == 0 && mdo->backedge_count() > 0) {
-    _invocation_counter = 1; // invocation counter may be slightly off
+    // Avoid skewing counter data during OSR compilation.
+    // Sometimes, MDO is allocated during the very first invocation and OSR compilation is triggered
+    // solely by backedge counter while invocation counter stays zero. In such case, it's important
+    // to observe non-zero invocation count to properly scale profile counts (see ciMethod::scale_count()).
+    _invocation_counter = 1;
   }
 
-  _state = (mdo->is_mature() ? mature_state : immature_state);
+  _state = mdo->is_mature() ? mature_state : immature_state;
   _eflags = mdo->eflags();
   _arg_local = mdo->arg_local();
   _arg_stack = mdo->arg_stack();

--- a/src/hotspot/share/ci/ciMethodData.cpp
+++ b/src/hotspot/share/ci/ciMethodData.cpp
@@ -248,8 +248,11 @@ bool ciMethodData::load_data() {
 
   // Note:  Extra data are all BitData, and do not need translation.
   _invocation_counter = mdo->invocation_count();
-  _state = mdo->is_mature()? mature_state: immature_state;
+  if (_invocation_counter == 0 && mdo->backedge_count() > 0) {
+    _invocation_counter = 1; // invocation counter may be slightly off
+  }
 
+  _state = (mdo->is_mature() ? mature_state : immature_state);
   _eflags = mdo->eflags();
   _arg_local = mdo->arg_local();
   _arg_stack = mdo->arg_stack();


### PR DESCRIPTION
After [JDK-8272330](https://bugs.openjdk.org/browse/JDK-8272330), OSR compilations may completely miss loop optimizations pass due to misleading profiling data. The cleanup changed how profile counts are scaled and it had surprising effect on OSR compilations. 

For a long-running loop it's common to have an MDO allocated during the first invocation while running in the loop. Also, OSR compilation may be scheduled while running the very first method invocation. In such case, `MethodData::invocation_counter() == 0` while `MethodData::backedge_counter() > 0`. Before JDK-8272330 went in, `ciMethod::scale_count()` took into account both `invocation_counter()` and `backedge_counter()`. Now `MethodData::invocation_counter()` is taken by `ciMethod::scale_count()` as is and it forces all counts to be unconditionally scaled to `1`. 

It misleads `IdealLoopTree::beautify_loops()` to believe there are no hot
backedges in the loop being compiled and `IdealLoopTree::split_outer_loop()`
doesn't kick in thus effectively blocking any further loop optimizations.

Proposed fix bumps `MethodData::invocation_counter()` from `0` to `1` and
enables `ciMethod::scale_count()` to report sane numbers.

Testing: 
- hs-tier1 - hs-tier4

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8280320](https://bugs.openjdk.org/browse/JDK-8280320): C2: Loop opts are missing during OSR compilation


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [ce36c789](https://git.openjdk.org/jdk19/pull/38/files/ce36c7890408338fba6f0e84e44d2b0d69ba89f8)
 * [Igor Veresov](https://openjdk.org/census#iveresov) (@veresov - **Reviewer**) ⚠️ Review applies to [ce36c789](https://git.openjdk.org/jdk19/pull/38/files/ce36c7890408338fba6f0e84e44d2b0d69ba89f8)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/38/head:pull/38` \
`$ git checkout pull/38`

Update a local copy of the PR: \
`$ git checkout pull/38` \
`$ git pull https://git.openjdk.org/jdk19 pull/38/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 38`

View PR using the GUI difftool: \
`$ git pr show -t 38`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/38.diff">https://git.openjdk.org/jdk19/pull/38.diff</a>

</details>
