### PR TITLE
8288445: AArch64: C2 compilation fails with guarantee(!true || (true && (shift != 0))) failed: impossible encoding

### DIFF
--- a/src/hotspot/cpu/aarch64/aarch64.ad
+++ b/src/hotspot/cpu/aarch64/aarch64.ad
@@ -4440,6 +4440,16 @@ operand immI_65535()
   interface(CONST_INTER);
 %}
 
+operand immI_positive()
+%{
+  predicate(n->get_int() > 0);
+  match(ConI);
+
+  op_cost(0);
+  format %{ %}
+  interface(CONST_INTER);
+%}
+
 operand immL_255()
 %{
   predicate(n->get_long() == 255L);

--- a/src/hotspot/cpu/aarch64/aarch64_neon.ad
+++ b/src/hotspot/cpu/aarch64/aarch64_neon.ad
@@ -4721,7 +4721,7 @@ instruct vsll16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate((n->as_Vector()->length() == 4 || n->as_Vector()->length() == 8) &&
             assert_not_var_shift(n));
   match(Set dst (RShiftVB src (RShiftCntV shift)));
@@ -4736,7 +4736,7 @@ instruct vsra8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16 && assert_not_var_shift(n));
   match(Set dst (RShiftVB src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4750,7 +4750,7 @@ instruct vsra16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate((n->as_Vector()->length() == 4 || n->as_Vector()->length() == 8) &&
             assert_not_var_shift(n));
   match(Set dst (URShiftVB src (RShiftCntV shift)));
@@ -4770,7 +4770,7 @@ instruct vsrl8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16 && assert_not_var_shift(n));
   match(Set dst (URShiftVB src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -4978,7 +4978,7 @@ instruct vsll8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate((n->as_Vector()->length() == 2 || n->as_Vector()->length() == 4) &&
             assert_not_var_shift(n));
   match(Set dst (RShiftVS src (RShiftCntV shift)));
@@ -4993,7 +4993,7 @@ instruct vsra4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8 && assert_not_var_shift(n));
   match(Set dst (RShiftVS src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5007,7 +5007,7 @@ instruct vsra8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate((n->as_Vector()->length() == 2 || n->as_Vector()->length() == 4) &&
             assert_not_var_shift(n));
   match(Set dst (URShiftVS src (RShiftCntV shift)));
@@ -5027,7 +5027,7 @@ instruct vsrl4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8 && assert_not_var_shift(n));
   match(Set dst (URShiftVS src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5218,7 +5218,7 @@ instruct vsll4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsra2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 && assert_not_var_shift(n));
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5231,7 +5231,7 @@ instruct vsra2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsra4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4 && assert_not_var_shift(n));
   match(Set dst (RShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5244,7 +5244,7 @@ instruct vsra4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrl2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 && assert_not_var_shift(n));
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5257,7 +5257,7 @@ instruct vsrl2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrl4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4 && assert_not_var_shift(n));
   match(Set dst (URShiftVI src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5356,7 +5356,7 @@ instruct vsll2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsra2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsra2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 && assert_not_var_shift(n));
   match(Set dst (RShiftVL src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5369,7 +5369,7 @@ instruct vsra2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrl2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrl2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2 && assert_not_var_shift(n));
   match(Set dst (URShiftVL src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -5382,7 +5382,7 @@ instruct vsrl2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5396,7 +5396,7 @@ instruct vsraa8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (AddVB dst (RShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5410,7 +5410,7 @@ instruct vsraa16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5424,7 +5424,7 @@ instruct vsraa4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVS dst (RShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5438,7 +5438,7 @@ instruct vsraa8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsraa2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5451,7 +5451,7 @@ instruct vsraa2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsraa4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVI dst (RShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5464,7 +5464,7 @@ instruct vsraa4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsraa2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsraa2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVL dst (RShiftVL src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5477,7 +5477,7 @@ instruct vsraa2L_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla8B_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla8B_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5492,7 +5492,7 @@ instruct vsrla8B_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla16B_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla16B_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 16);
   match(Set dst (AddVB dst (URShiftVB src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5507,7 +5507,7 @@ instruct vsrla16B_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla4S_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla4S_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5522,7 +5522,7 @@ instruct vsrla4S_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla8S_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla8S_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 8);
   match(Set dst (AddVS dst (URShiftVS src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5537,7 +5537,7 @@ instruct vsrla8S_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla2I_imm(vecD dst, vecD src, immI shift) %{
+instruct vsrla2I_imm(vecD dst, vecD src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5550,7 +5550,7 @@ instruct vsrla2I_imm(vecD dst, vecD src, immI shift) %{
   ins_pipe(vshift64_imm);
 %}
 
-instruct vsrla4I_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla4I_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 4);
   match(Set dst (AddVI dst (URShiftVI src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -5563,7 +5563,7 @@ instruct vsrla4I_imm(vecX dst, vecX src, immI shift) %{
   ins_pipe(vshift128_imm);
 %}
 
-instruct vsrla2L_imm(vecX dst, vecX src, immI shift) %{
+instruct vsrla2L_imm(vecX dst, vecX src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == 2);
   match(Set dst (AddVL dst (URShiftVL src (RShiftCntV shift))));
   ins_cost(INSN_COST);

--- a/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
+++ b/src/hotspot/cpu/aarch64/aarch64_neon_ad.m4
@@ -2199,7 +2199,7 @@ instruct vsll$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRA_IMM', `
-instruct vsra$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
+instruct vsra$1$2_imm`'(vec$4 dst, vec$4 src, immI_positive shift) %{
   PREDICATE(`$1$2', $1, assert_not_var_shift(n))
   match(Set dst (RShiftV$2 src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -2221,7 +2221,7 @@ instruct vsra$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRL_IMM', `
-instruct vsrl$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
+instruct vsrl$1$2_imm`'(vec$4 dst, vec$4 src, immI_positive shift) %{
   PREDICATE(`$1$2', $1, assert_not_var_shift(n))
   match(Set dst (URShiftV$2 src (RShiftCntV shift)));
   ins_cost(INSN_COST);
@@ -2253,7 +2253,7 @@ instruct vsrl$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRLA_IMM', `
-instruct vsrla$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
+instruct vsrla$1$2_imm`'(vec$4 dst, vec$4 src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == $1);
   match(Set dst (AddV$2 dst (URShiftV$2 src (RShiftCntV shift))));
   ins_cost(INSN_COST);
@@ -2277,7 +2277,7 @@ instruct vsrla$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
 %}')dnl
 dnl
 define(`VSRAA_IMM', `
-instruct vsraa$1$2_imm`'(vec$4 dst, vec$4 src, immI shift) %{
+instruct vsraa$1$2_imm`'(vec$4 dst, vec$4 src, immI_positive shift) %{
   predicate(n->as_Vector()->length() == $1);
   match(Set dst (AddV$2 dst (RShiftV$2 src (RShiftCntV shift))));
   ins_cost(INSN_COST);

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -39,10 +39,10 @@ public class ShiftByZero {
 
     public static void bMeth() {
         int shift = i32[0];
+        // This loop is to confuse the optimizer, so that "shift" is
+        // optimized to 0 only after loop vectorization. 
         for (int i8 = 279; i8 > 1; --i8) {
             shift <<= 6;
-            >> This is to confuse the optimizer, so that "shift" is
-            >> optimized to 0 only after loop vectorization. 
         }
         // low 6 bits of shift are 0, so shift can be
         // simplified to constant 0

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -1,0 +1,74 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288445
+ * @summary Test shift by 0
+ * @library /test/lib
+ * @run main compiler.codegen.ShiftByZero
+ * @run main/othervm -Xbatch -XX:-TieredCompilation
+ * -XX:+PrintOptoAssembly
+ * compiler.codegen.ShiftByZero
+ */
+
+package compiler.codegen;
+
+public class ShiftByZero {
+
+    public static final int N = 64;
+
+    public static int[] i32 = new int[N];
+
+    public static void bMeth() {
+        int shift = i32[0];
+        for (int i8 = 279; i8 > 1; --i8) {
+            shift <<= 6;
+        }
+        // low 6 bits of i1 are 0, so shift by i1 can be
+        // simplified to shift by 0
+        {
+            for (int i = 0; i < N; ++i) {
+                i32[i] += i32[i] >>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] += i32[i] >>>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] >>>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] >>= shift;
+            }
+            for (int i = 0; i < N; ++i) {
+                i32[i] <<= shift;
+            }
+        }
+    }
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 20_000; i++ ) {
+            bMeth();
+        }
+    }
+}

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -41,6 +41,8 @@ public class ShiftByZero {
         int shift = i32[0];
         for (int i8 = 279; i8 > 1; --i8) {
             shift <<= 6;
+            >> This is to confuse the optimizer, so that "shift" is
+            >> optimized to 0 only after loop vectorization. 
         }
         // low 6 bits of shift are 0, so shift can be
         // simplified to constant 0

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -40,7 +40,7 @@ public class ShiftByZero {
     public static void bMeth() {
         int shift = i32[0];
         // This loop is to confuse the optimizer, so that "shift" is
-        // optimized to 0 only after loop vectorization. 
+        // optimized to 0 only after loop vectorization.
         for (int i8 = 279; i8 > 1; --i8) {
             shift <<= 6;
         }

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -44,8 +44,8 @@ public class ShiftByZero {
         for (int i8 = 279; i8 > 1; --i8) {
             shift <<= 6;
         }
-        // low 6 bits of i1 are 0, so shift by i1 can be
-        // simplified to shift by 0
+        // low 6 bits of shift are 0, so shift can be
+        // simplified to constant 0
         {
             for (int i = 0; i < N; ++i) {
                 i32[i] += i32[i] >>= shift;

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -66,7 +66,7 @@ public class ShiftByZero {
     }
 
     public static void main(String[] strArr) {
-        for (int i = 0; i < 20_000; i++ ) {
+        for (int i = 0; i < 20_000; i++) {
             bMeth();
         }
     }

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -28,7 +28,6 @@
  * @library /test/lib
  * @run main compiler.codegen.ShiftByZero
  * @run main/othervm -Xbatch -XX:-TieredCompilation
- * -XX:+PrintOptoAssembly
  * compiler.codegen.ShiftByZero
  */
 

--- a/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
+++ b/test/hotspot/jtreg/compiler/codegen/ShiftByZero.java
@@ -25,8 +25,6 @@
  * @test
  * @bug 8288445
  * @summary Test shift by 0
- * @library /test/lib
- * @run main compiler.codegen.ShiftByZero
  * @run main/othervm -Xbatch -XX:-TieredCompilation
  * compiler.codegen.ShiftByZero
  */


### PR DESCRIPTION
The range for aarch64 vector right-shift is 1 to the element width.  This issue fixes the problem in the back-end.  There is a separate problem in the front-end that shift by 0 is not always optimized out.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288445](https://bugs.openjdk.org/browse/JDK-8288445): AArch64: C2 compilation fails with guarantee(!true || (true && (shift != 0))) failed: impossible encoding


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**) ⚠️ Review applies to [0f927ce7](https://git.openjdk.org/jdk19/pull/40/files/0f927ce7b9e7d66d57de03ee71e2f18ee594195c)
 * [Hao Sun](https://openjdk.org/census#haosun) (@shqking - Author)
 * [Ningsheng Jian](https://openjdk.org/census#njian) (@nsjian - Committer)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/40/head:pull/40` \
`$ git checkout pull/40`

Update a local copy of the PR: \
`$ git checkout pull/40` \
`$ git pull https://git.openjdk.org/jdk19 pull/40/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 40`

View PR using the GUI difftool: \
`$ git pr show -t 40`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/40.diff">https://git.openjdk.org/jdk19/pull/40.diff</a>

</details>
