### PR TITLE
8286836: Crash in GetSetLocalTest: No support for deferred values in continuations

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -644,6 +644,13 @@ void VM_BaseGetOrSetLocal::doit() {
     return;
   }
   if (_set) {
+    if (fr.is_heap_frame()) { // we want this check after the check for JVMTI_ERROR_INVALID_SLOT
+      assert(_depth == 0 && Continuation::is_frame_in_continuation(_jvf->thread(), fr), "sanity check");
+      // the safepoint could be as we return to the return barrier but before we execute it (poll return)
+      _result = JVMTI_ERROR_OPAQUE_FRAME; // deferred locals currently unsupported in continuations
+      return;
+    }
+
     // Force deoptimization of frame if compiled because it's
     // possible the compiler emitted some locals as constant values,
     // meaning they are not mutable.

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
@@ -35,8 +35,7 @@ import java.util.concurrent.*;
 public class GetSetLocalTest {
     private static final String agentLib = "GetSetLocalTest";
 
-    static final int MSG_COUNT = 600*1000;
-    static final SynchronousQueue<String> QUEUE = new SynchronousQueue<>();
+    static SynchronousQueue<String> QUEUE;
     static native boolean completed();
     static native void enableEvents(Thread thread);
     static native void testSuspendedVirtualThreads(Thread thread);
@@ -56,19 +55,17 @@ public class GetSetLocalTest {
 
     static final Runnable PRODUCER = () -> {
         try {
-            for (int i = 0; i < MSG_COUNT; i++) {
-                if (completed()) {
-                    consumer.interrupt();
-                    break;
-                }
+            while (!completed()) {
                 producer("msg: ");
             }
-        } catch (InterruptedException e) { }
+            consumer.interrupt();
+        } catch (InterruptedException e) {
+        }
     };
 
     static final Runnable CONSUMER = () -> {
         try {
-            for (int i = 0; i < MSG_COUNT; i++) {
+            while(true) {
                 String s = QUEUE.take();
             }
         } catch (InterruptedException e) {
@@ -77,6 +74,7 @@ public class GetSetLocalTest {
     };
 
     public static void test1() throws Exception {
+        QUEUE = new SynchronousQueue<>();
         producer = Thread.ofVirtual().name("VThread-Producer").start(PRODUCER);
         consumer = Thread.ofVirtual().name("VThread-Consumer").start(CONSUMER);
 
@@ -101,6 +99,10 @@ public class GetSetLocalTest {
         }
 
         GetSetLocalTest obj = new GetSetLocalTest();
-        obj.runTest();
+
+        for (int i = 0; i < 1000; i++) {
+            obj.runTest();
+        }
+
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
@@ -487,7 +487,11 @@ Java_GetSetLocalTest_testSuspendedVirtualThreads(JNIEnv *jni, jclass klass, jthr
 
 JNIEXPORT jboolean JNICALL
 Java_GetSetLocalTest_completed(JNIEnv *jni, jclass klass) {
-  return completed;
+  if (completed) {
+    completed = JNI_FALSE;
+    return JNI_TRUE;
+  }
+  return JNI_FALSE;
 }
 
 } // extern "C"


### PR DESCRIPTION
The JVMTI `SetLocalXXX` requires the target virtual thread suspended at a breakpoint or single step event.

This is the relevant statement from the `"Local Variable"` section:

  `The SetLocalXXX functions may be used to set the value of a local variable in the topmost frame of a virtual thread suspended at a breakpoint or single step event.`

This fix is to return the JVMTI_ERROR_OPAQUE_FRAME in cases when the target thread is not at a breakpoint or single step event. In this case the assert described in the bug report is avoided:
```
open/src/hotspot/share/runtime/vframe.cpp:300
# assert(stack_chunk() == __null) failed: Not supported for heap frames 
```

Also, this is an analysis from Ron:
```
The problem occurs because the thread is suspended at a safepoint poll on return in the oldest thawed frame. The safepoint happens after the frame is popped but before it returns to the return barrier, thawing the caller (and so the stack looks as if we're in enterSpecial). In that case the virtual thread's topmost frame is still frozen on the heap, even though it is mounted.

However, the spec says that a set local operation should succeed for the topmost frame of a mounted virtual thread only if the thread is suspended *at a breakpoint or a single-step event*, and I don't think we can stop at that safepoint in that case.

If so, the fix is simple: if we're trying to set, even if the virtual thread is mounted and the depth is zero, if the frame is a heap frame, we should return an OPAQUE_FRAME error. The test should be changed as well to accept such an error if the thread is suspended not at a breakpoint/single-step. 
```

Changes GetSetLocalTest test are taken from the repo-loom repository. It was an update from Leonid which is needed to reproduce this problem.

The fix was tested with thousands of runs of the GetSetLocalTest on Linux, Windows and MacOs.

Will also submit nsk.jvmti and nsk.jdi test runs on mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286836](https://bugs.openjdk.org/browse/JDK-8286836): Crash in GetSetLocalTest: No support for deferred values in continuations


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/41/head:pull/41` \
`$ git checkout pull/41`

Update a local copy of the PR: \
`$ git checkout pull/41` \
`$ git pull https://git.openjdk.org/jdk19 pull/41/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 41`

View PR using the GUI difftool: \
`$ git pr show -t 41`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/41.diff">https://git.openjdk.org/jdk19/pull/41.diff</a>

</details>
