### PR TITLE
8286580: serviceability/jvmti/vthread/GetSetLocalTest failed with assert: Not supported for heap frames

### DIFF
--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -644,6 +644,13 @@ void VM_BaseGetOrSetLocal::doit() {
     return;
   }
   if (_set) {
+    if (fr.is_heap_frame()) { // we want this check after the check for JVMTI_ERROR_INVALID_SLOT
+      assert(_depth == 0 && Continuation::is_frame_in_continuation(_jvf->thread(), fr), "sanity check");
+      // the safepoint could be as we return to the return barrier but before we execute it (poll return)
+      _result = JVMTI_ERROR_OPAQUE_FRAME; // deferred locals currently unsupported in continuations
+      return;
+    }
+
     // Force deoptimization of frame if compiled because it's
     // possible the compiler emitted some locals as constant values,
     // meaning they are not mutable.

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -645,7 +645,7 @@ void VM_BaseGetOrSetLocal::doit() {
   }
   if (_set) {
     if (fr.is_heap_frame()) { // we want this check after the check for JVMTI_ERROR_INVALID_SLOT
-      assert(_depth == 0 && Continuation::is_frame_in_continuation(_jvf->thread(), fr), "sanity check");
+      assert(Continuation::is_frame_in_continuation(_jvf->thread(), fr), "sanity check");
       // the safepoint could be as we return to the return barrier but before we execute it (poll return)
       _result = JVMTI_ERROR_OPAQUE_FRAME; // deferred locals currently unsupported in continuations
       return;

--- a/src/hotspot/share/prims/jvmtiImpl.cpp
+++ b/src/hotspot/share/prims/jvmtiImpl.cpp
@@ -651,7 +651,6 @@ void VM_BaseGetOrSetLocal::doit() {
       // but the caller frame has not been thawed. We can't support a JVMTI SetLocal in the callee
       // frame at this point, because we aren't truly in the callee yet.
       // fr.is_heap_frame() is impossible if a continuation is at a single step or breakpoint.
-      // In such cases the top frames can't be frozen because of an agent callback frame.
       _result = JVMTI_ERROR_OPAQUE_FRAME; // deferred locals are not fully supported in continuations
       return;
     }

--- a/test/hotspot/jtreg/ProblemList.txt
+++ b/test/hotspot/jtreg/ProblemList.txt
@@ -111,6 +111,7 @@ serviceability/sa/sadebugd/DebugdConnectTest.java 8239062,8270326 macosx-x64,mac
 serviceability/sa/TestRevPtrsForInvokeDynamic.java 8241235 generic-all
 
 serviceability/jvmti/ModuleAwareAgents/ThreadStart/MAAThreadStart.java 8225354 windows-all
+serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java 8286836 generic-all
 serviceability/dcmd/gc/RunFinalizationTest.java 8227120 linux-all,windows-x64
 
 serviceability/sa/ClhsdbCDSCore.java 8269982,8267433 macosx-aarch64,macosx-x64

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
@@ -100,7 +100,7 @@ public class GetSetLocalTest {
 
         GetSetLocalTest obj = new GetSetLocalTest();
 
-        for (int i = 0; i < 1000; i++) {
+        for (int i = 0; i < 200; i++) {
             obj.runTest();
         }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/GetSetLocalTest.java
@@ -35,8 +35,7 @@ import java.util.concurrent.*;
 public class GetSetLocalTest {
     private static final String agentLib = "GetSetLocalTest";
 
-    static final int MSG_COUNT = 600*1000;
-    static final SynchronousQueue<String> QUEUE = new SynchronousQueue<>();
+    static SynchronousQueue<String> QUEUE;
     static native boolean completed();
     static native void enableEvents(Thread thread);
     static native void testSuspendedVirtualThreads(Thread thread);
@@ -56,19 +55,17 @@ public class GetSetLocalTest {
 
     static final Runnable PRODUCER = () -> {
         try {
-            for (int i = 0; i < MSG_COUNT; i++) {
-                if (completed()) {
-                    consumer.interrupt();
-                    break;
-                }
+            while (!completed()) {
                 producer("msg: ");
             }
-        } catch (InterruptedException e) { }
+            consumer.interrupt();
+        } catch (InterruptedException e) {
+        }
     };
 
     static final Runnable CONSUMER = () -> {
         try {
-            for (int i = 0; i < MSG_COUNT; i++) {
+            while(true) {
                 String s = QUEUE.take();
             }
         } catch (InterruptedException e) {
@@ -77,6 +74,7 @@ public class GetSetLocalTest {
     };
 
     public static void test1() throws Exception {
+        QUEUE = new SynchronousQueue<>();
         producer = Thread.ofVirtual().name("VThread-Producer").start(PRODUCER);
         consumer = Thread.ofVirtual().name("VThread-Consumer").start(CONSUMER);
 
@@ -101,6 +99,10 @@ public class GetSetLocalTest {
         }
 
         GetSetLocalTest obj = new GetSetLocalTest();
-        obj.runTest();
+
+        for (int i = 0; i < 1000; i++) {
+            obj.runTest();
+        }
+
     }
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
@@ -487,7 +487,11 @@ Java_GetSetLocalTest_testSuspendedVirtualThreads(JNIEnv *jni, jclass klass, jthr
 
 JNIEXPORT jboolean JNICALL
 Java_GetSetLocalTest_completed(JNIEnv *jni, jclass klass) {
-  return completed;
+  if (completed) {
+    completed = JNI_FALSE;
+    return JNI_TRUE;
+  }
+  return JNI_FALSE;
 }
 
 } // extern "C"

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/GetSetLocalTest/libGetSetLocalTest.cpp
@@ -232,7 +232,7 @@ test_GetLocal(jvmtiEnv *jvmti, JNIEnv *jni, jthread cthread, jthread vthread,
 
 static bool
 test_SetLocal(jvmtiEnv *jvmti, JNIEnv *jni, jthread cthread, jthread vthread,
-              int depth, int frame_count, Values *values) {
+              int depth, int frame_count, Values *values, bool at_event) {
   jvmtiError err;
 
   LOG("test_SetLocal: mounted: %d depth: %d fcount: %d\n", cthread != NULL, depth, frame_count);
@@ -288,7 +288,7 @@ test_SetLocal(jvmtiEnv *jvmti, JNIEnv *jni, jthread cthread, jthread vthread,
       fatal(jni, "JVMTI SetLocalObject for unmounted vthread pr depth > 0failed to return JVMTI_ERROR_OPAQUE_FRAME");
     }
     return false; // skip testing other types for unmounted vthread
-  } else if (err == JVMTI_ERROR_OPAQUE_FRAME) {
+  } else if (!at_event && err == JVMTI_ERROR_OPAQUE_FRAME) {
     LOG("JVMTI SetLocalObject for mounted vthread at depth=0 returned JVMTI_ERROR_OPAQUE_FRAME: %d\n", err);
     return false; // skip testing other types for compiled frame that can't be deoptimized
   }
@@ -309,7 +309,7 @@ test_SetLocal(jvmtiEnv *jvmti, JNIEnv *jni, jthread cthread, jthread vthread,
 }
 
 static void
-test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int frame_count) {
+test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int frame_count, bool at_event) {
   Values values0 = { NULL, NULL, 1, 2L, (jfloat)3.2F, (jdouble)4.500000047683716 };
   Values values1 = { NULL, NULL, 2, 3L, (jfloat)4.2F, (jdouble)5.500000047683716 };
   jthread cthread = get_carrier_thread(jvmti, jni, vthread);
@@ -319,8 +319,8 @@ test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int f
 
   LOG("test_GetSetLocal: test_GetLocal with values0\n");
   test_GetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values0);
-  LOG("test_GetSetLocal: test_SetLocal with values1\n");
-  bool success = test_SetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values1);
+  LOG("test_GetSetLocal: test_SetLocal at_event: %d with values1\n", at_event);
+  bool success = test_SetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values1, at_event);
 
   if (!success) {
     goto End; // skip testing for compiled frame that can't be deoptimized
@@ -334,8 +334,8 @@ test_GetSetLocal(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread, int depth, int f
   } else {
     LOG("test_GetSetLocal: test_GetLocal with values1\n");
     test_GetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values1);
-    LOG("test_GetSetLocal: test_SetLocal with values0 to restore original local values\n");
-    test_SetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values0);
+    LOG("test_GetSetLocal: test_SetLocal at_event: %d with values0 to restore original local values\n", at_event);
+    test_SetLocal(jvmti, jni, cthread, vthread, depth, frame_count, &values0, at_event);
   }
  End:
   LOG("test_GetSetLocal: finished\n\n");
@@ -360,7 +360,7 @@ Breakpoint(jvmtiEnv *jvmti, JNIEnv* jni, jthread vthread,
 
   {
     int frame_count = get_frame_count(jvmti, jni, vthread);
-    test_GetSetLocal(jvmti, jni, vthread, depth, frame_count);
+    test_GetSetLocal(jvmti, jni, vthread, depth, frame_count, true /* at_event */);
   }
   deallocate(jvmti, jni, (void*)mname);
   deallocate(jvmti, jni, (void*)tname);
@@ -470,7 +470,7 @@ Java_GetSetLocalTest_testSuspendedVirtualThreads(JNIEnv *jni, jclass klass, jthr
 #if 0
       print_stack_trace(jvmti, jni, vthread);
 #endif
-      test_GetSetLocal(jvmti, jni, vthread, depth, frame_count);
+      test_GetSetLocal(jvmti, jni, vthread, depth, frame_count, false /* !at_event */);
     }
 
     err = jvmti->ResumeThread(vthread);


### PR DESCRIPTION
The JVMTI SetLocalXXX requires the target virtual thread suspended at a breakpoint or single step event.

This is the relevant statement from the "Local Variable" section:

`The SetLocalXXX functions may be used to set the value of a local variable in the topmost frame of a virtual thread suspended at a breakpoint or single step event.
`
This fix is to return the JVMTI_ERROR_OPAQUE_FRAME in cases when the target thread is not at a breakpoint or single step event. In this case the assert described in the bug report is avoided:

```
open/src/hotspot/share/runtime/vframe.cpp:300
# assert(stack_chunk() == __null) failed: Not supported for heap frames 
```
Also, this is an analysis from Ron:
```
The problem occurs because the thread is suspended at a safepoint poll on return in the oldest thawed frame. The safepoint happens after the frame is popped but before it returns to the return barrier, thawing the caller (and so the stack looks as if we're in enterSpecial). In that case the virtual thread's topmost frame is still frozen on the heap, even though it is mounted.

However, the spec says that a set local operation should succeed for the topmost frame of a mounted virtual thread only if the thread is suspended *at a breakpoint or a single-step event*, and I don't think we can stop at that safepoint in that case.

If so, the fix is simple: if we're trying to set, even if the virtual thread is mounted and the depth is zero, if the frame is a heap frame, we should return an OPAQUE_FRAME error. The test should be changed as well to accept such an error if the thread is suspended not at a breakpoint/single-step. 

```
Changes `GetSetLocalTest` test are taken from the repo-loom repository. It was an update from Leonid which is needed to reproduce this problem.

The fix was tested with thousands of runs of the `GetSetLocalTest` on Linux, Windows and MacOs.

Will also submit nsk.jvmti and nsk.jdi test runs on mach5.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8286580](https://bugs.openjdk.org/browse/JDK-8286580): serviceability/jvmti/vthread/GetSetLocalTest failed with assert: Not supported for heap frames


### Reviewers
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**) ⚠️ Review applies to [108e3a46](https://git.openjdk.org/jdk19/pull/42/files/108e3a468f2b762e61a28f35fa66b1b92d2d836d)
 * [Ron Pressler](https://openjdk.org/census#rpressler) (@pron - Author) ⚠️ Review applies to [ca7c3b3a](https://git.openjdk.org/jdk19/pull/42/files/ca7c3b3a15be066e4f01e5ec6a9e8322fd2f6533)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/42/head:pull/42` \
`$ git checkout pull/42`

Update a local copy of the PR: \
`$ git checkout pull/42` \
`$ git pull https://git.openjdk.org/jdk19 pull/42/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 42`

View PR using the GUI difftool: \
`$ git pr show -t 42`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/42.diff">https://git.openjdk.org/jdk19/pull/42.diff</a>

</details>
