### PR TITLE
8287800: JFR: Incorrect error message when starting recording with missing .jfc file

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.dcmd;
 
-import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.InvalidPathException;
@@ -32,7 +31,6 @@ import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.text.ParseException;
 import java.time.Duration;
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -53,6 +51,7 @@ import jdk.jfr.internal.SecuritySupport;
 import jdk.jfr.internal.Type;
 import jdk.jfr.internal.jfc.JFC;
 import jdk.jfr.internal.jfc.model.JFCModel;
+import jdk.jfr.internal.jfc.model.JFCModelException;
 import jdk.jfr.internal.jfc.model.XmlInput;
 
 /**
@@ -229,22 +228,23 @@ final class DCmdStart extends AbstractDCmd {
         for (String configName : settings) {
             try {
                 s.putAll(JFC.createKnown(configName).getSettings());
-            } catch(FileNotFoundException e) {
-                throw new DCmdException("Could not find settings file'" + configName + "'", e);
-            } catch (IOException | ParseException e) {
-                throw new DCmdException("Could not parse settings file '" + settings[0] + "'", e);
-            }
+            } catch (InvalidPathException | IOException | ParseException e) {
+                throw new DCmdException(JFC.formatException("Could not", e, configName), e);
+            } 
         }
         return s;
     }
 
     private LinkedHashMap<String, String> configureExtended(String[] settings, ArgumentParser parser) throws DCmdException {
-        List<SafePath> paths = new ArrayList<>();
+        JFCModel model = new JFCModel(l -> logWarning(l));
         for (String setting : settings) {
-            paths.add(JFC.createSafePath(setting));
+            try {
+                model.parse(JFC.createSafePath(setting));
+            } catch (InvalidPathException | IOException | JFCModelException | ParseException e) {
+                throw new DCmdException(JFC.formatException("Could not", e, setting), e);
+            }
         }
         try {
-            JFCModel model = new JFCModel(paths, l -> logWarning(l));
             Set<String> jfcOptions = new HashSet<>();
             for (XmlInput input : model.getInputs()) {
                 jfcOptions.add(input.getName());
@@ -266,13 +266,9 @@ final class DCmdStart extends AbstractDCmd {
                 }
             }
             return model.getSettings();
-         } catch (IllegalArgumentException iae) {
+        } catch (IllegalArgumentException iae) {
              throw new DCmdException(iae.getMessage()); // spelling error, invalid value
-         } catch (FileNotFoundException ioe) {
-             throw new DCmdException("Could not find settings file'" + settings[0] + "'", ioe);
-         } catch (IOException | ParseException e) {
-             throw new DCmdException("Could not parse settings file '" + settings[0] + "'", e);
-         }
+        }
     }
 
     // Instruments JDK-events on class load to reduce startup time
@@ -436,7 +432,7 @@ final class DCmdStart extends AbstractDCmd {
                 }
             }
             return sb.toString();
-        } catch (IOException | ParseException e) {
+        } catch (IOException | JFCModelException | ParseException  e) {
             Logger.log(LogTag.JFR_DCMD, LogLevel.DEBUG, "Could not list .jfc options for JFR.start. " + e.getMessage());
             return "";
         }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/dcmd/DCmdStart.java
@@ -230,7 +230,7 @@ final class DCmdStart extends AbstractDCmd {
                 s.putAll(JFC.createKnown(configName).getSettings());
             } catch (InvalidPathException | IOException | ParseException e) {
                 throw new DCmdException(JFC.formatException("Could not", e, configName), e);
-            } 
+            }
         }
         return s;
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
@@ -301,7 +301,7 @@ public final class JFC {
         }
         return message;
     }
-    
+
     private static String exceptionToVerb(Exception e) {
         if (e instanceof FileNotFoundException || e instanceof NoSuchFileException) {
             return "find";

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFC.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -25,12 +25,13 @@
 
 package jdk.jfr.internal.jfc;
 
-import java.io.FileReader;
+import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.Reader;
 import java.io.StringReader;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.AccessDeniedException;
 import java.nio.file.Files;
 import java.nio.file.NoSuchFileException;
 import java.nio.file.Path;
@@ -41,6 +42,7 @@ import java.util.Arrays;
 import java.util.List;
 
 import jdk.jfr.Configuration;
+import jdk.jfr.internal.jfc.model.JFCModelException;
 import jdk.jfr.internal.LogLevel;
 import jdk.jfr.internal.LogTag;
 import jdk.jfr.internal.Logger;
@@ -118,7 +120,11 @@ public final class JFC {
      * @see java.lang.SecurityManager#checkRead(java.lang.String)
      */
     public static Configuration create(String name, Reader reader) throws IOException, ParseException {
-        return JFCParser.createConfiguration(name, reader);
+        try {
+            return JFCParser.createConfiguration(name, reader);
+        } catch (ParseException pe) {
+            throw new ParseException("Error reading JFC file. " + pe.getMessage(), -1);
+        }
     }
 
     /**
@@ -281,6 +287,34 @@ public final class JFC {
                 return new StringReader(c.content);
             }
         }
-        return new FileReader(sf.toFile(), StandardCharsets.UTF_8);
+        return Files.newBufferedReader(sf.toFile().toPath(), StandardCharsets.UTF_8);
+    }
+
+    public static String formatException(String prefix, Exception e, String input) {
+        String message = prefix + " " + JFC.exceptionToVerb(e) + " file '" + input + "'";
+        String details = e.getMessage();
+        if (e instanceof JFCModelException m) {
+            return message +  ". " + details;
+        }
+        if (e instanceof ParseException && !details.isEmpty()) {
+            return message +  ". " + details;
+        }
+        return message;
+    }
+    
+    private static String exceptionToVerb(Exception e) {
+        if (e instanceof FileNotFoundException || e instanceof NoSuchFileException) {
+            return "find";
+        }
+        if (e instanceof ParseException) {
+            return "parse";
+        }
+        if (e instanceof JFCModelException) {
+            return "use";
+        }
+        if (e instanceof AccessDeniedException) {
+            return "access";
+        }
+        return "open";  // InvalidPath, IOException
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/JFCParser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -54,12 +54,8 @@ final class JFCParser {
             JFCParserHandler ch = new JFCParserHandler();
             parseXML(content, ch);
             return PrivateAccess.getInstance().newConfiguration(name, ch.label, ch.description, ch.provider, ch.settings, content);
-        } catch (IllegalArgumentException iae) {
-            throw new ParseException(iae.getMessage(), -1);
-        } catch (SAXException e) {
-            ParseException pe =  new ParseException("Error reading JFC file. " + e.getMessage(), -1);
-            pe.initCause(e);
-            throw pe;
+        } catch (IllegalArgumentException | SAXException e) {
+            throw new ParseException(e.getMessage(), -1);
         }
     }
 
@@ -69,7 +65,7 @@ final class JFCParser {
         parser.parse(new InputSource(r), ch);
     }
 
-    private static String readContent(Reader r) throws IOException {
+    private static String readContent(Reader r) throws IOException, ParseException {
         CharArrayWriter writer = new CharArrayWriter(1024);
         int count = 0;
         int ch;

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModel.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -44,39 +44,43 @@ import static java.nio.charset.StandardCharsets.UTF_8;
 public final class JFCModel {
     private final Map<String, List<ControlElement>> controls = new LinkedHashMap<>();
     private final XmlConfiguration configuration;
+    private final Consumer<String> logger;
 
-    private JFCModel(XmlConfiguration configuration) throws ParseException {
+    private JFCModel(XmlConfiguration configuration) throws JFCModelException {
         configuration.validate();
         this.configuration = configuration;
+        this.logger = x -> { }; // Nothing to log.
     }
 
-    public JFCModel(Reader reader,  Consumer<String> logger) throws ParseException, IOException {
+    public JFCModel(Reader reader,  Consumer<String> logger) throws IOException, JFCModelException, ParseException {
         this(Parser.parse(reader));
         addControls();
         wireConditions();
         wireSettings(logger);
     }
 
-    public JFCModel(List<SafePath> files, Consumer<String> logger) throws IOException, ParseException {
+    public JFCModel(Consumer<String> logger) {
         this.configuration = new XmlConfiguration();
         this.configuration.setAttribute("version", "2.0");
-        for (SafePath file : files) {
-            JFCModel model = JFCModel.create(file, logger);
-            for (var entry : model.controls.entrySet()) {
-                String name = entry.getKey();
-                // Fail-fast checks that prevents an ambiguous file to be written later
-                if (controls.containsKey(name)) {
-                    throw new ParseException("Control with '" + name + "' is declared in multiple files", 0);
-                }
-                controls.put(name, entry.getValue());
+        this.logger = logger;
+    }
+
+    public void parse(SafePath file) throws IOException, JFCModelException, ParseException {
+        JFCModel model = JFCModel.create(file, logger);
+        for (var entry : model.controls.entrySet()) {
+            String name = entry.getKey();
+            // Fail-fast checks that prevents an ambiguous file to be written later
+            if (controls.containsKey(name)) {
+                throw new JFCModelException("Control with '" + name + "' is declared in multiple files");
             }
-            for (XmlElement child : model.configuration.getChildren()) {
-                this.configuration.addChild(child);
-            }
+            controls.put(name, entry.getValue());
+        }
+        for (XmlElement child : model.configuration.getChildren()) {
+            this.configuration.addChild(child);
         }
     }
 
-    public static JFCModel create(SafePath file, Consumer<String> logger) throws ParseException, IOException {
+    public static JFCModel create(SafePath file, Consumer<String> logger) throws IOException, JFCModelException, ParseException{
         if (file.toString().equals("none")) {
             XmlConfiguration configuration = new XmlConfiguration();
             configuration.setAttribute("version", "2.0");

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModelException.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModelException.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -23,30 +23,13 @@
  * questions.
  */
 package jdk.jfr.internal.jfc.model;
-
-import java.util.List;
-
-// Base class for <condition>, <or>, <not>, <and> and <test>
-abstract class XmlExpression extends XmlElement {
-
-    public final List<XmlExpression> getExpressions() {
-        return elements(XmlExpression.class);
-    }
-
-    @Override
-    protected List<Constraint> constraints() {
-        return List.of(
-            Constraint.any(XmlOr.class),
-            Constraint.any(XmlAnd.class),
-            Constraint.any(XmlTest.class),
-            Constraint.any(XmlNot.class)
-        );
-    }
-
-    @Override
-    protected void validateChildConstraints() throws JFCModelException {
-        if (getExpressions().size() < 2) {
-            throw new JFCModelException("Expected + <" + getElementName() + "> to have at least two children");
-        }
+/**
+ * Signals that a JFCModel is invalid.
+ */
+public final class JFCModelException extends Exception {
+    private static final long serialVersionUID = -613252344752758699L;
+    
+    public JFCModelException(String errorMessage) {
+        super(errorMessage);
     }
 }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModelException.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/JFCModelException.java
@@ -28,7 +28,7 @@ package jdk.jfr.internal.jfc.model;
  */
 public final class JFCModelException extends Exception {
     private static final long serialVersionUID = -613252344752758699L;
-    
+
     public JFCModelException(String errorMessage) {
         super(errorMessage);
     }

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/Parser.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/Parser.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -29,7 +29,6 @@ import java.io.Reader;
 import java.text.ParseException;
 import java.util.ArrayDeque;
 import java.util.Deque;
-
 import jdk.internal.org.xml.sax.Attributes;
 import jdk.internal.org.xml.sax.InputSource;
 import jdk.internal.org.xml.sax.SAXException;
@@ -45,10 +44,8 @@ final class Parser {
             ConfigurationHandler handler = new ConfigurationHandler();
             saxParser.parse(new InputSource(reader), handler);
             return handler.configuration;
-        } catch (SAXException sp) {
-            ParseException pe = new ParseException(sp.getMessage(), -1);
-            pe.initCause(sp);
-            throw pe;
+        } catch (SAXException | IllegalStateException e) {
+            throw new ParseException(e.getMessage(), -1);
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlCondition.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlCondition.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.jfc.model;
 
-import java.text.ParseException;
 import java.util.List;
 import java.util.Optional;
 
@@ -45,9 +44,9 @@ final class XmlCondition extends XmlExpression implements ControlElement {
     }
 
     @Override
-    protected void validateChildConstraints() throws ParseException {
+    protected void validateChildConstraints() throws JFCModelException {
         if (getExpressions().size() > 1) {
-            throw new ParseException("Expected <condition> to not have more than one child", -1);
+            throw new JFCModelException("Expected <condition> to not have more than one child");
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlConfiguration.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlConfiguration.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.jfc.model;
 
-import java.text.ParseException;
 import java.util.List;
 import java.util.Optional;
 
@@ -85,10 +84,10 @@ final class XmlConfiguration extends XmlElement {
     }
 
     @Override
-    protected void validateAttributes() throws ParseException {
+    protected void validateAttributes() throws JFCModelException {
         super.validateAttributes();
         if (!attribute("version").equals("2.0")) {
-            throw new ParseException("Only .jfc files of version 2.0 is supported", -1);
+            throw new JFCModelException("Only .jfc files of version 2.0 is supported");
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlElement.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.jfc.model;
 
-import java.text.ParseException;
 import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
@@ -63,7 +62,7 @@ class XmlElement {
         return attributes;
     }
 
-    final void validate() throws ParseException {
+    final void validate() throws JFCModelException {
         validateAttributes();
         validateChildConstraints();
         validateChildren();
@@ -179,35 +178,35 @@ class XmlElement {
         return producers.get(0).evaluate();
     }
 
-    protected void validateAttributes() throws ParseException {
+    protected void validateAttributes() throws JFCModelException {
         for (String key : attributes()) {
             if (!attributes.containsKey(key)) {
-                throw new ParseException("Missing mandatory attribute '" + key + "'", 0);
+                throw new JFCModelException("Missing mandatory attribute '" + key + "'");
             }
         }
     }
 
-    private void validateChildren() throws ParseException {
+    private void validateChildren() throws JFCModelException {
         for (XmlElement child : elements) {
             child.validate();
         }
     }
 
-    protected void validateChildConstraints() throws ParseException {
+    protected void validateChildConstraints() throws JFCModelException {
         for (Constraint c : constraints()) {
             validateConstraint(c);
         }
     }
 
-    private final void validateConstraint(Constraint c) throws ParseException {
+    private final void validateConstraint(Constraint c) throws JFCModelException {
         int count = count(c.type());
         if (count < c.min()) {
             String elementName = Utilities.elementName(c.type());
-            throw new ParseException("Missing mandatory element <" + elementName + ">", 0);
+            throw new JFCModelException("Missing mandatory element <" + elementName + ">");
         }
         if (count > c.max()) {
             String elementName = Utilities.elementName(c.type());
-            throw new ParseException("Too many elements of type <" + elementName + ">", 0);
+            throw new JFCModelException("Too many elements of type <" + elementName + ">");
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlNot.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlNot.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.jfc.model;
 
-import java.text.ParseException;
 import java.util.List;
 
 // Corresponds to <not>
@@ -36,9 +35,9 @@ final class XmlNot extends XmlExpression {
     }
 
     @Override
-    protected void validateChildConstraints() throws ParseException {
+    protected void validateChildConstraints() throws JFCModelException {
         if (getExpressions().size() != 1) {
-            throw new ParseException("Expected <not> to have a single child", 0);
+            throw new JFCModelException("Expected <not> to have a single child");
         }
     }
 

--- a/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlTest.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/internal/jfc/model/XmlTest.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2021, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -24,7 +24,6 @@
  */
 package jdk.jfr.internal.jfc.model;
 
-import java.text.ParseException;
 import java.util.List;
 
 // Corresponds to <test>
@@ -53,17 +52,17 @@ final class XmlTest extends XmlExpression {
     }
 
     @Override
-    protected void validateChildConstraints() throws ParseException {
+    protected void validateChildConstraints() throws JFCModelException {
         if (!getExpressions().isEmpty()) {
-            throw new ParseException("Expected <test> to not have child elements", 0);
+            throw new JFCModelException("Expected <test> to not have child elements");
         }
     }
 
     @Override
-    protected void validateAttributes() throws ParseException {
+    protected void validateAttributes() throws JFCModelException {
         super.validateAttributes();
         if (!getOperator().equalsIgnoreCase("equal")) {
-            throw new ParseException("Unknown operator '" + getOperator() + "', only supported is 'equal'", 0);
+            throw new JFCModelException("Unknown operator '" + getOperator() + "', only supported is 'equal'");
         }
     }
 

--- a/test/jdk/jdk/jfr/jcmd/JcmdAsserts.java
+++ b/test/jdk/jdk/jfr/jcmd/JcmdAsserts.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2015, 2018, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2015, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -65,7 +65,7 @@ public class JcmdAsserts {
 //    }
 
     public static void assertNotAbleToFindSettingsFile(OutputAnalyzer output) {
-        output.shouldContain("Could not parse setting");
+        output.shouldContain("Could not find file");
     }
 
     public static void assertNoRecordingsAvailable(OutputAnalyzer output) {


### PR DESCRIPTION
Could I have a review of PR that fixes incorrect error messages when starting a recording.

The current message is very confusing. If a user types`jcmd <pid> JFR.start settings=my.jfc`, but doesn't realise that the path should be relative to where the JVM started, the error message says "Could not parse settings file custom.jfc"

It should say "Could not **find** file custom.jfc"

Furthermore, if a user specifies `settings=default.jfc settings=my.jfc`to get settings from two files, the error message will say "Could not parse file default.jfc", even though it was my.jfc it was unable to find.

This problem impacts `jfr configure`, `-XX:StartFlightRecording` and `JFR.start`. Code has been refactored so error formatting now happens per file and in one place with a proper verb ("find", "parse", "use", "access", "open"). Error messages from the parser are also propagated, for example: "Could not parse file 'my.jfc". Expected root element to be named 'configuration'"

Testing: jdk/jdk/jfr

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287800](https://bugs.openjdk.org/browse/JDK-8287800): JFR: Incorrect error message when starting recording with missing .jfc file


### Reviewers
 * [Markus Grönlund](https://openjdk.org/census#mgronlun) (@mgronlun - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/43/head:pull/43` \
`$ git checkout pull/43`

Update a local copy of the PR: \
`$ git checkout pull/43` \
`$ git pull https://git.openjdk.org/jdk19 pull/43/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 43`

View PR using the GUI difftool: \
`$ git pr show -t 43`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/43.diff">https://git.openjdk.org/jdk19/pull/43.diff</a>

</details>
