### PR TITLE
8288528: broken links in java.desktop

### DIFF
--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -5,7 +5,7 @@
   <title>AWT Threading Issues</title>
 </head>
 <!--
- Copyright (c) 2002, 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 2002, 2022, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -118,11 +118,7 @@ The implementation-specific details are given below.
 Implementation-dependent behavior.
 </h3>
 
-Prior to 1.4, the helper threads were never terminated.
-<p>
-Starting with 1.4, the behavior has changed as a result of the fix for
-<a href="https://bugs.openjdk.org/browse/JDK-4030718">
-4030718</a>. With the current implementation, AWT terminates all its
+AWT terminates all its
 helper threads allowing the application to exit cleanly when the
 following three conditions are true:
 <ul>

--- a/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
+++ b/src/java.desktop/share/classes/java/awt/doc-files/AWTThreadIssues.html
@@ -121,7 +121,7 @@ Implementation-dependent behavior.
 Prior to 1.4, the helper threads were never terminated.
 <p>
 Starting with 1.4, the behavior has changed as a result of the fix for
-<a href="https://bugs.java.com/view_bug.do?bug_id=4030718">
+<a href="https://bugs.openjdk.org/browse/JDK-4030718">
 4030718</a>. With the current implementation, AWT terminates all its
 helper threads allowing the application to exit cleanly when the
 following three conditions are true:
@@ -153,13 +153,7 @@ exit cleanly under normal conditions, it is not guaranteed that it
 will exit cleanly in all cases. Two examples:
 <ul>
   <li> Other packages can create displayable components for internal
-       needs and never make them undisplayable. See
-<a href="https://bugs.java.com/view_bug.do?bug_id=4515058">
-4515058</a>,
-<a href="https://bugs.java.com/view_bug.do?bug_id=4671025">
-4671025</a>, and
-<a href="https://bugs.java.com/view_bug.do?bug_id=4465537">
-4465537</a>.
+       needs and never make them undisplayable.
   <li> Both Microsoft Windows and X11 allow an application to send native
        events to windows that belong to another application. With this
        feature it is possible to write a malicious program that will

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2005, 2016, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2005, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -32,7 +32,7 @@ import java.util.List;
  * A class representing the tags found in an Exif IFD.  Exif is a
  * standard for annotating images used by most digital camera
  * manufacturers.  The Exif specification may be found at
- *<a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+ * <a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
  * {@code https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf}
  * </a>.
  *

--- a/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
+++ b/src/java.desktop/share/classes/javax/imageio/plugins/tiff/ExifTIFFTagSet.java
@@ -32,8 +32,8 @@ import java.util.List;
  * A class representing the tags found in an Exif IFD.  Exif is a
  * standard for annotating images used by most digital camera
  * manufacturers.  The Exif specification may be found at
- * <a href="http://www.exif.org/Exif2-2.PDF">
- * {@code http://www.exif.org/Exif2-2.PDF}
+ *<a href="https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf">
+ * {@code https://www.cipa.jp/std/documents/e/DC-008-2012_E.pdf}
  * </a>.
  *
  * <p> The definitions of the data types referenced by the field

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -2140,9 +2140,8 @@ public class MetalLookAndFeel extends BasicLookAndFeel
 
     /**
      * Returns a {@code LayoutStyle} implementing the Java look and feel
-     * design guidelines as specified at
-     * <a href="http://www.oracle.com/technetwork/java/hig-136467.html">http://www.oracle.com/technetwork/java/hig-136467.html</a>.
-     *
+     * design guidelines.
+     * 
      * @return LayoutStyle implementing the Java look and feel design
      *         guidelines
      * @since 1.6

--- a/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
+++ b/src/java.desktop/share/classes/javax/swing/plaf/metal/MetalLookAndFeel.java
@@ -2141,7 +2141,7 @@ public class MetalLookAndFeel extends BasicLookAndFeel
     /**
      * Returns a {@code LayoutStyle} implementing the Java look and feel
      * design guidelines.
-     * 
+     *
      * @return LayoutStyle implementing the Java look and feel design
      *         guidelines
      * @since 1.6

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
@@ -33,19 +33,6 @@
 <main role="main">
 <h1>Using the Multiplexing Look and Feel</h1>
 
-<blockquote>
-<hr>
-<p>
-<i>
-This document is based on an article
-originally published in
-<a href="http://www.oracle.com/technetwork/java/javase/tech/articles-jsp-139072.html"
-   target="_top"><em>The Swing Connection</em></a>.
-</i>
-</p>
-<hr>
-</blockquote>
-
 <p>
 The Multiplexing look and feel lets
 you supplement an ordinary look and feel

--- a/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
+++ b/src/java.desktop/share/classes/javax/swing/plaf/multi/doc-files/multi_tsc.html
@@ -5,7 +5,7 @@
   <title>Using the Multiplexing Look and Feel</title>
 </head>
 <!--
- Copyright (c) 1998, 2021, Oracle and/or its affiliates. All rights reserved.
+ Copyright (c) 1998, 2022, Oracle and/or its affiliates. All rights reserved.
  DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
 
  This code is free software; you can redistribute it and/or modify it


### PR DESCRIPTION
doccheck reports some broken links which are rectified. copyright year updated for files.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288528](https://bugs.openjdk.org/browse/JDK-8288528): broken links in java.desktop


### Reviewers
 * [Phil Race](https://openjdk.org/census#prr) (@prrace - **Reviewer**) ⚠️ Review applies to [286be6eb](https://git.openjdk.org/jdk19/pull/44/files/286be6eb7f83d323b53e9e5184c0c5ecd543044e)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/44/head:pull/44` \
`$ git checkout pull/44`

Update a local copy of the PR: \
`$ git checkout pull/44` \
`$ git pull https://git.openjdk.org/jdk19 pull/44/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 44`

View PR using the GUI difftool: \
`$ git pr show -t 44`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/44.diff">https://git.openjdk.org/jdk19/pull/44.diff</a>

</details>
