### PR TITLE
8288741: JFR: Change package name of snippet files

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/snippet-files/Snippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package example2;
+package jdk.jfr.snippets.consumer;
 
 import java.io.IOException;
 import java.nio.file.Path;

--- a/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/snippet-files/Snippets.java
@@ -22,7 +22,7 @@
  * or visit www.oracle.com if you need additional information or have any
  * questions.
  */
-package example1;
+package jdk.jfr.snippets;
 
 import jdk.jfr.AnnotationElement;
 import jdk.jfr.ValueDescriptor;


### PR DESCRIPTION
Could I have a review of PR that changes package names of the JFR snippet files. Today they are named "example1" and "example2" in the default package. It looks strange to see them on top and before jdk.jfr when browsing classes in jrt-fs.jar, for example in Eclipse.

Testing: build docs + tier1 + tier2

Thanks
Erik