### PR TITLE
JDK-8288671: Problematic fix for font boosting

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/resources/stylesheet.css
@@ -62,9 +62,9 @@ h5 {
 h6 {
     font-size:13px;
 }
-/* Disable font boosting */
-h1, h2, h3, h4, h5, h6 {
-    max-height: 2em;
+/* Disable font boosting for selected elements */
+h1, h2, h3, h4, h5, h6, div.member-signature {
+    max-height: 1000em;
 }
 ul {
     list-style-type:disc;


### PR DESCRIPTION
Please review an important CSS-only fix for the output generated by JavaDoc. 

Various mobile browsers have a feature called "font boosting" or "text inflation" to selectively increase the font size of parts of the page to make them easier to read. Since javadoc-generated pages have a `<meta name="viewport" content="width=device-width, initial-scale=1">` declaration that is not really needed, but especially Chrome on Android is very stubborn and insists on changing font sizes in an unpredictable way. 

It seems like the only way to prevent Chrome/Android from doing this is to include a `min-height` CSS property. In JDK-8277420 we therefore included the CSS declaration shown below to avoid headers from changing font size when the copy-to-clipboard button is shown:

```
/* Disable font boosting */
h1, h2, h3, h4, h5, h6 {
    max-height: 2em;
} 
```

The idea was that a max-height of `2em` would be enough for how headers are displayed in our docs, but of course I didn't consider wrapped headers. In fact, the main header of the index page is often wrapped twice on small browsers/devices, resulting in the header overlapping with the first paragraph:

![Screenshot_20220620-171055~2](https://user-images.githubusercontent.com/15975/174652966-c7815d9f-1b2f-407c-b241-f11c91e0eca6.png)

Font boosting also occurs in member signatures where some parts are displayed with bigger fonts than others. This is less obvious than the other cases, but it should also be fixed:

![Screenshot_20220620-104706~2](https://user-images.githubusercontent.com/15975/174653488-c22f30c8-086f-4533-86f0-43100dee155d.png)

The proposed fix is to use a very high `max-height` value that is far beyond actual height values, and to include member signatures in the CSS selector.

This fixes the problems in the screenshots above in Chrome/Android as shown in the screenshots below. It does not have any effects in other browsers.
 
![Screenshot_20220620-171105~2](https://user-images.githubusercontent.com/15975/174655060-19575a49-2b2c-40cd-ad36-f181f275b2bb.png)
Fixed index page

![Screenshot_20220620-104658~2](https://user-images.githubusercontent.com/15975/174655086-5c18dbf6-bd82-43be-bb07-b187f2b89c82.png)
Fixed member signature

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288671](https://bugs.openjdk.org/browse/JDK-8288671): Problematic fix for font boosting


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/48/head:pull/48` \
`$ git checkout pull/48`

Update a local copy of the PR: \
`$ git checkout pull/48` \
`$ git pull https://git.openjdk.org/jdk19 pull/48/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 48`

View PR using the GUI difftool: \
`$ git pr show -t 48`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/48.diff">https://git.openjdk.org/jdk19/pull/48.diff</a>

</details>
