### PR TITLE
8288840: StructureViolationException should not link to fork method

### DIFF
--- a/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructureViolationException.java
+++ b/src/jdk.incubator.concurrent/share/classes/jdk/incubator/concurrent/StructureViolationException.java
@@ -27,7 +27,6 @@ package jdk.incubator.concurrent;
 /**
  * Thrown when a structure violation is detected.
  *
- * @see StructuredTaskScope#fork(Callable)
  * @see StructuredTaskScope#close()
  *
  * @since 19


### PR DESCRIPTION
StructureViolationException has a `@see` link to a fork method that does not throw this exception. The link should be removed for JDK 19. We'll add the link back once the JEP for Extent-Local Variables is integrated.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288840](https://bugs.openjdk.org/browse/JDK-8288840): StructureViolationException should not link to fork method


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/52/head:pull/52` \
`$ git checkout pull/52`

Update a local copy of the PR: \
`$ git checkout pull/52` \
`$ git pull https://git.openjdk.org/jdk19 pull/52/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 52`

View PR using the GUI difftool: \
`$ git pr show -t 52`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/52.diff">https://git.openjdk.org/jdk19/pull/52.diff</a>

</details>
