### PR TITLE
8288529: broken link in java.xml

### DIFF
--- a/src/java.xml/share/classes/javax/xml/validation/package-info.java
+++ b/src/java.xml/share/classes/javax/xml/validation/package-info.java
@@ -39,27 +39,27 @@
  *     <li><strong>Document Type Definition (DTD)</strong>
  *         - XML's built-in schema language.
  *     </li>
- *     <li><strong><a href="http://www.w3.org/XML/Schema">W3C XML Schema (WXS)</a></strong> -
+ *     <li><strong><a href="https://www.w3.org/XML/Schema">W3C XML Schema (WXS)</a></strong> -
  *         an object-oriented XML schema language. WXS also provides a type system
  *         for constraining the character data of an XML document. WXS is maintained
- *         by the <a href="http://www.w3.org">World Wide Web Consortium (W3C)</a>
+ *         by the <a href="https://www.w3.org">World Wide Web Consortium (W3C)</a>
  *         and is a W3C Recommendation (that is, a ratified W3C standard specification).
  *     </li>
- *     <li><strong><a href="http://www.relaxng.org">RELAX NG (RNG)</a></strong> -
+ *     <li><strong><a href="https://relaxng.org/">RELAX NG (RNG)</a></strong> -
  *         a pattern-based, user-friendly XML schema language. RNG schemas may
  *         also use types to constrain XML character data. RNG is maintained by
- *         the <a href="http://www.oasis-open.org">Organization for the Advancement
+ *         the <a href="https://www.oasis-open.org">Organization for the Advancement
  *         of Structured Information Standards (OASIS)</a> and is both an OASIS
- *         and an <a href="http://www.iso.org">ISO (International Organization
+ *         and an <a href="https://www.iso.org/home.html">ISO (International Organization
  *         for Standardization)</a> standard.
  *     </li>
- *     <li><strong><a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/c055982_ISO_IEC_19757-3_2016.zip">Schematron</a></strong> -
+ *     <li><strong><a href="https://standards.iso.org/ittf/PubliclyAvailableStandards/c055982_ISO_IEC_19757-3_2016.zip">Schematron</a></strong> -
  *         a rules-based XML schema language. Whereas DTD, WXS, and RNG are designed
  *         to express the structure of a content model, Schematron is designed to
  *         enforce individual rules that are difficult or impossible to express
  *         with other schema languages. Schematron is intended to supplement a
  *         schema written in structural schema language such as the aforementioned.
- *         Schematron is <a href="http://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">an ISO standard</a>.
+ *         Schematron is <a href="https://standards.iso.org/ittf/PubliclyAvailableStandards/index.html">an ISO standard</a>.
  *     </li>
  * </ul>
  * <p>


### PR DESCRIPTION
Some of the links cause redirection, iso.org in particular took 1-2 seconds, that looks like was longer than the wait time of the doccheck and docs link checker. Changed it to the current homepage to avoid redirection. Also changed other links within this package. 

I'm limiting the change to this package only as iso.org only appears in it and other redirections have not caused any issue (tests showed they were almost instant).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288529](https://bugs.openjdk.org/browse/JDK-8288529): broken link in java.xml


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)
 * [Lance Andersen](https://openjdk.org/census#lancea) (@LanceAndersen - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/55/head:pull/55` \
`$ git checkout pull/55`

Update a local copy of the PR: \
`$ git checkout pull/55` \
`$ git pull https://git.openjdk.org/jdk19 pull/55/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 55`

View PR using the GUI difftool: \
`$ git pr show -t 55`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/55.diff">https://git.openjdk.org/jdk19/pull/55.diff</a>

</details>
