### PR TITLE
8288846: misc tests fail "assert(ms < 1000) failed: Un-interruptable sleep, short time use only"

### DIFF
--- a/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
+++ b/src/hotspot/share/jfr/periodic/sampling/jfrThreadSampler.cpp
@@ -508,8 +508,8 @@ void JfrThreadSampler::run() {
     int64_t native_period_millis = get_native_period();
     native_period_millis = native_period_millis == 0 ? max_jlong : MAX2<int64_t>(native_period_millis, 1);
 
-    // If both period fields are 0, it implies the sampler is in the process
-    // of disenrolling. Loop back for graceful disenroll by means of the semaphore.
+    // If both periods are max_jlong, it implies the sampler is in the process of
+    // disenrolling. Loop back for graceful disenroll by means of the semaphore.
     if (java_period_millis == max_jlong && native_period_millis == max_jlong) {
       continue;
     }

--- a/test/jdk/jdk/jfr/event/sampling/TestNative.java
+++ b/test/jdk/jdk/jfr/event/sampling/TestNative.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2017, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2017, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -48,9 +48,12 @@ public class TestNative {
 
     static volatile boolean alive = true;
 
+    // Please resist the temptation to speed up the test by decreasing
+    // the period. It is explicity set to 1100 ms to provoke the 1000 ms
+    // threshold in the JVM for os::naked_short_sleep().
     public static void main(String[] args) throws Exception {
         try (RecordingStream rs = new RecordingStream()) {
-            rs.enable(NATIVE_EVENT).withPeriod(Duration.ofMillis(1));
+            rs.enable(NATIVE_EVENT).withPeriod(Duration.ofMillis(1100));
             rs.onEvent(NATIVE_EVENT, e -> {
                 alive = false;
                 rs.close();


### PR DESCRIPTION
Greetings,

this is a small adjustment to rectify the consequence of [JDK-8288663](https://bugs.openjdk.org/browse/JDK-8288663).

Testing: jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288846](https://bugs.openjdk.org/browse/JDK-8288846): misc tests fail "assert(ms < 1000) failed: Un-interruptable sleep, short time use only"


### Reviewers
 * [Erik Gahlin](https://openjdk.org/census#egahlin) (@egahlin - **Reviewer**) ⚠️ Review applies to [2a22151c](https://git.openjdk.org/jdk19/pull/57/files/2a22151c4375865d41fabf69ce52b60c6c85743f)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/57/head:pull/57` \
`$ git checkout pull/57`

Update a local copy of the PR: \
`$ git checkout pull/57` \
`$ git pull https://git.openjdk.org/jdk19 pull/57/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 57`

View PR using the GUI difftool: \
`$ git pr show -t 57`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/57.diff">https://git.openjdk.org/jdk19/pull/57.diff</a>

</details>
