### PR TITLE
8247407: tools/jlink/plugins/CompressorPluginTest.java test failing

### DIFF
--- a/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
+++ b/src/java.base/share/classes/jdk/internal/jimage/ImageReader.java
@@ -458,7 +458,11 @@ public final class ImageReader implements AutoCloseable {
                     makeDirectories(path);
                 } else { // a resource
                     makeDirectories(childloc.buildName(true, true, false));
-                    newResource(dir, childloc);
+                    // if we have already created a resource for this name previously, then don't
+                    // recreate it
+                    if (!nodes.containsKey(childloc.getFullName(true))) {
+                        newResource(dir, childloc);
+                    }
                 }
             });
             dir.setCompleted(true);
@@ -753,6 +757,7 @@ public final class ImageReader implements AutoCloseable {
         }
 
         void addChild(Node node) {
+            assert !children.contains(node) : "Child " + node + " already added";
             children.add(node);
         }
 

--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -695,7 +695,6 @@ javax/swing/JTable/8236907/LastVisibleRow.java 8284619 macosx-all
 
 # core_tools
 
-tools/jlink/plugins/CompressorPluginTest.java                   8247407 generic-all
 
 ############################################################################
 

--- a/test/jdk/tools/jimage/ImageReaderDuplicateChildNodesTest.java
+++ b/test/jdk/tools/jimage/ImageReaderDuplicateChildNodesTest.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+import jdk.internal.jimage.ImageReader;
+
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * @test
+ * @bug 8247407
+ * @summary Test that ImageReader doesn't create a Directory node with duplicate children
+ * @modules java.base/jdk.internal.jimage
+ * @run main ImageReaderDuplicateChildNodesTest
+ */
+public class ImageReaderDuplicateChildNodesTest {
+
+    /**
+     * Uses the ImageReader to open and read the JAVA_HOME/lib/modules image. Tests that the
+     * {@link ImageReader#findNode(String)} corresponding to a directory doesn't return a node
+     * with duplicate children in it.
+     */
+    public static void main(final String[] args) throws Exception {
+        final Path imagePath = Paths.get(System.getProperty("java.home"), "lib", "modules");
+        if (!Files.exists(imagePath)) {
+            // skip the testing in the absence of the image file
+            System.err.println("Skipping test since " + imagePath + " is absent");
+            return;
+        }
+        System.out.println("Running test against image " + imagePath);
+        final String integersParentResource = "/modules/java.base/java/lang";
+        final String integerResource = integersParentResource + "/Integer.class";
+        try (final ImageReader reader = ImageReader.open(imagePath)) {
+            // find the child node/resource first
+            final ImageReader.Node integerNode = reader.findNode(integerResource);
+            if (integerNode == null) {
+                throw new RuntimeException("ImageReader could not locate " + integerResource
+                        + " in " + imagePath);
+            }
+            // now find the parent node (which will represent a directory)
+            final ImageReader.Node parent = reader.findNode(integersParentResource);
+            if (parent == null) {
+                throw new RuntimeException("ImageReader could not locate " + integersParentResource
+                        + " in " + imagePath);
+            }
+            // now verify that the parent node which is a directory, doesn't have duplicate children
+            final List<ImageReader.Node> children = parent.getChildren();
+            if (children == null || children.isEmpty()) {
+                throw new RuntimeException("ImageReader did not return any child resources under "
+                        + integersParentResource + " in " + imagePath);
+            }
+            final Set<ImageReader.Node> uniqueChildren = new HashSet<>();
+            for (final ImageReader.Node child : children) {
+                final boolean unique = uniqueChildren.add(child);
+                if (!unique) {
+                    throw new RuntimeException("ImageReader returned duplicate child resource "
+                            + child + " under " + parent + " from image " + imagePath);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
Can I please get a review for this change which fixes an issue in `jdk.internal.jimage.ImageReader`? 

The `ImageReader` maintains a map of `nodes` which it uses to keep track of directories/resources from within the image. When a `findNode` is called, it leads to building the `Node` if the node isn't present in the map or if isn't complete (i.e. if the directory's immediate child nodes haven't been built). During this building of nodes, the code can end up creating a directory node and then visiting the child resources to create nodes for those resources. While doing so, the code currently doesn't check if a (child) node for the resource was already created previously (during a different call) and added to the parent directory's `children` list. As a result, it ends up adding the child node more than once.

One way to solve this would have been to make the `children` in `Directory` be a `Set`. I suspect it's currently a `List` so as to keep track of the order? If we did make it a `Set`, we could still keep the order using a `LinkedHashSet`. But changing this to a `Set` doesn't look feasible because there's a `List<Node> getChildren()` API on `Directory`, which would then have to create a copy of the `Set` to return as a `List`.

The commit in this PR instead prevents adding the child more than once by checking the `nodes` map for the presence of the child. This new check is added only for "resources" and not directories, because `makeDirectory` already skips a `Node` creation if the `nodes` has the corresponding entry (line 564 in the current PR).
Additionally an `assert` has been added to `addChild` of `Directory`.

A new jtreg test has been added which reproduces the issue without this change and verifies the fix.

This part of the code is very new to me, so if there's anything more to be considered, then please let me know.

tier1, tier2, tier3 testing is currently in progress.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8247407](https://bugs.openjdk.org/browse/JDK-8247407): tools/jlink/plugins/CompressorPluginTest.java test failing


### Reviewers
 * [Athijegannathan Sundararajan](https://openjdk.org/census#sundar) (@sundararajana - **Reviewer**) ⚠️ Review applies to [40bc7db8](https://git.openjdk.org/jdk19/pull/60/files/40bc7db8b2860cecfccad694e3bcc81b260f707c)
 * [Jim Laskey](https://openjdk.org/census#jlaskey) (@JimLaskey - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/60/head:pull/60` \
`$ git checkout pull/60`

Update a local copy of the PR: \
`$ git checkout pull/60` \
`$ git pull https://git.openjdk.org/jdk19 pull/60/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 60`

View PR using the GUI difftool: \
`$ git pr show -t 60`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/60.diff">https://git.openjdk.org/jdk19/pull/60.diff</a>

</details>
