### PR TITLE
8288080: (fc) FileChannel::map for MemorySegments should state it always throws UOE

### DIFF
--- a/src/java.base/share/classes/java/nio/channels/FileChannel.java
+++ b/src/java.base/share/classes/java/nio/channels/FileChannel.java
@@ -997,6 +997,9 @@ public abstract class FileChannel
      *           of mapped memory associated with the returned mapped memory
      *           segment is unspecified and should not be relied upon.
      *
+     * @implSpec The default implementation of this method throws
+     *           {@code UnsupportedOperationException}.
+     *
      * @param   mode
      *          The file mapping mode, see
      *          {@link FileChannel#map(FileChannel.MapMode, long, long)};


### PR DESCRIPTION
`FileChannel::map` for `MemorySegment`s should state it always throws UOE.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8288080](https://bugs.openjdk.org/browse/JDK-8288080): (fc) FileChannel::map for MemorySegments should state it always throws UOE
 * [JDK-8288081](https://bugs.openjdk.org/browse/JDK-8288081): (fc) FileChannel::map for MemorySegments should state it always throws UOE (**CSR**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/63/head:pull/63` \
`$ git checkout pull/63`

Update a local copy of the PR: \
`$ git checkout pull/63` \
`$ git pull https://git.openjdk.org/jdk19 pull/63/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 63`

View PR using the GUI difftool: \
`$ git pr show -t 63`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/63.diff">https://git.openjdk.org/jdk19/pull/63.diff</a>

</details>
