### PR TITLE
8288983: broken link in com.sun.net.httpserver.SimpleFileServer

### DIFF
--- a/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
+++ b/src/jdk.httpserver/share/classes/com/sun/net/httpserver/SimpleFileServer.java
@@ -42,8 +42,7 @@ import sun.net.httpserver.simpleserver.OutputFilter;
  * A simple HTTP file server and its components (intended for testing,
  * development and debugging purposes only).
  *
- * <p> A <a href="#server-impl">simple file server</a> is composed of three
- * components:
+ * <p> A simple file server is composed of three components:
  * <ul>
  *   <li> an {@link HttpServer HttpServer} that is bound to a given address, </li>
  *   <li> an {@link HttpHandler HttpHandler} that serves files from a given


### PR DESCRIPTION
Can I please get a review for this change which fixes the broken link in the javadoc of `SimpleFileServer`? This fixes https://bugs.openjdk.org/browse/JDK-8288983 which has the necessary context on why/when this link broke.

I used the doccheck tool https://github.com/openjdk/doccheck (which is what identified that issue in first place), before and after the change in this PR. The issue is no longer reported after this change.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288983](https://bugs.openjdk.org/browse/JDK-8288983): broken link in com.sun.net.httpserver.SimpleFileServer


### Reviewers
 * [Daniel Fuchs](https://openjdk.org/census#dfuchs) (@dfuch - **Reviewer**)
 * [Aleksei Efimov](https://openjdk.org/census#aefimov) (@AlekseiEfimov - Committer)
 * [Michael McMahon](https://openjdk.org/census#michaelm) (@Michael-Mc-Mahon - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/64/head:pull/64` \
`$ git checkout pull/64`

Update a local copy of the PR: \
`$ git checkout pull/64` \
`$ git pull https://git.openjdk.org/jdk19 pull/64/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 64`

View PR using the GUI difftool: \
`$ git pr show -t 64`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/64.diff">https://git.openjdk.org/jdk19/pull/64.diff</a>

</details>
