### PR TITLE
8288683: C2: And node gets wrong type due to not adding it back to the worklist in CCP

### DIFF
--- a/src/hotspot/share/opto/phaseX.hpp
+++ b/src/hotspot/share/opto/phaseX.hpp
@@ -568,6 +568,8 @@ class PhaseCCP : public PhaseIterGVN {
   // Non-recursive.  Use analysis to transform single Node.
   virtual Node *transform_once( Node *n );
 
+  void push_and(Unique_Node_List& worklist, const Node* parent, const Node* use) const;
+
 public:
   PhaseCCP( PhaseIterGVN *igvn ); // Compute conditional constants
   NOT_PRODUCT( ~PhaseCCP(); )

--- a/test/hotspot/jtreg/compiler/c2/TestAndShiftZeroCCP.java
+++ b/test/hotspot/jtreg/compiler/c2/TestAndShiftZeroCCP.java
@@ -1,0 +1,90 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8288683
+ * @library /test/lib
+ * @summary Test that And nodes are added to the CCP worklist if it has an LShift as input.
+ * @run main/othervm -Xbatch compiler.c2.TestAndShiftZeroCCP
+ */
+package compiler.c2;
+
+import jdk.test.lib.Asserts;
+
+public class TestAndShiftZeroCCP {
+    static int iFld = 0xfffff;
+
+    public static void main(String[] strArr) {
+        for (int i = 0; i < 10000; i++) {
+            Asserts.assertEQ(testAndI(), 224);
+            Asserts.assertEQ(testAndL(), 224L);
+            Asserts.assertEQ(testAndLConvI2L(), 224L);
+        }
+    }
+
+    static int testAndI() {
+        int x = 10;
+        int y = iFld;
+        int z = 3;
+        int q;
+        for (int i = 62; i < 70; ++i) {
+            q = y << i;
+            for (int j = 0; j < 8; j++) {
+                z += i;
+            }
+            z = q & 0xff;
+        }
+        return z;
+    }
+
+    static long testAndL() {
+        long x = 10;
+        long y = iFld;
+        long z = 3;
+        long q;
+        for (int i = 62; i < 70; ++i) {
+            q = y << i;
+            for (int j = 0; j < 8; j++) {
+                z += i;
+            }
+            z = q & 0xff;
+        }
+        return z;
+    }
+
+    static long testAndLConvI2L() {
+        long x = 10;
+        long y = iFld;
+        long z = 3;
+        long q;
+        for (int i = 62; i < 70; ++i) {
+            q = y << i;
+            for (int j = 0; j < 8; j++) {
+                z += i;
+            }
+            z = q & 0xff;
+        }
+        return z;
+    }
+}


### PR DESCRIPTION
[JDK-8277850](https://bugs.openjdk.org/browse/JDK-8277850) added some new optimizations in `AndI/L::Value()` to optimize patterns similar to `(v << 2) & 3` which can directly be replaced by zero if the mask and the shifted value are bitwise disjoint. To do that, we look at the type of the shift value of the `LShift` input (right-hand side input):
https://github.com/openjdk/jdk19/blob/bdf9902f753b71f30be8e1634fc361a5c7d8d8ec/src/hotspot/share/opto/mulnode.cpp#L1752-L1765

The optimization as such works fine but there is a problem in CCP. After calling `Value()` for a node in CCP, we generally only add the direct users of it back to the worklist if the type changed:
https://github.com/openjdk/jdk19/blob/bdf9902f753b71f30be8e1634fc361a5c7d8d8ec/src/hotspot/share/opto/phaseX.cpp#L1812-L1814

We special case some nodes where we need to add additional nodes (grandchildren or even further down) back to the worklist to not miss updating them, for example, the `Phis` when the use is a `Region`:
https://github.com/openjdk/jdk19/blob/bdf9902f753b71f30be8e1634fc361a5c7d8d8ec/src/hotspot/share/opto/phaseX.cpp#L1789-L1796

However, we miss to special case an `LShift` use if the shift value (right-hand side input of the `LShift`) changed. We should add all `AndI/L` nodes back to the worklist to account for the `AndI/L::Value()` optimization. Not doing so can result in a wrong execution as shown with the testcase. We have the following nodes:
![Screenshot from 2022-06-24 10-28-41](https://user-images.githubusercontent.com/17833009/175496296-4280e26b-6f2f-4ddc-b164-b9e887a5d437.png)

The `LShiftI` node gets `int` as type (i.e. bottom) and is not put back on the worklist again since the type cannot improve anymore. Afterwards, we process the `AndI` node and call `AndI::Value()`. At this point, the phi node still has the temporary type `int:62`. We apply the optimization that the shifted number and the mask are bitwise disjoint and we set the type of the `AndI` node to `int:0`. When later reapplying `Phi::Value()` for the phi node, we correct the type to `int:62..69` and try to push the `LShiftI` node use back to the worklist. Since its type is `int`, we do not add it again. At this point, `AndI` is not on the CCP worklist anymore and neither will we push the `AndI` node to it again. We miss to reapply `AndI::Value()` and correct the now wrong `Value()` optimization. We keep `int:0` as type and replace the `AndI` node by constant zero - leading to a wrong execution.

Special casing `LShift` -> `AndNodes` in CCP fixes the problem to make sure we reapply `AndI/L::Value()` again. I've applied some more refactorings and comment improvements but since this fix is for JDK 19, I've decided to separate them into an RFE ([JDK-8289051](https://bugs.openjdk.org/browse/JDK-8289051)) to reduce the risk.

At some point, we should add some additional verification to find missed `Value()` calls in CCP to avoid similar problems in the future (see [JDK-8257197](https://bugs.openjdk.org/browse/JDK-8257197)).

Thanks,
Christian