### PR TITLE
8288949: serviceability/jvmti/vthread/ContStackDepthTest/ContStackDepthTest.java failing

### DIFF
--- a/src/hotspot/share/code/compiledIC.cpp
+++ b/src/hotspot/share/code/compiledIC.cpp
@@ -586,9 +586,6 @@ bool CompiledStaticCall::set_to_clean(bool in_use) {
   // Reset call site
   set_destination_mt_safe(resolve_call_stub());
 
-  // Do not reset stub here:  It is too expensive to call find_stub.
-  // Instead, rely on caller (nmethod::clear_inline_caches) to clear
-  // both the call and its stub.
   return true;
 }
 

--- a/src/hotspot/share/code/compiledMethod.cpp
+++ b/src/hotspot/share/code/compiledMethod.cpp
@@ -453,6 +453,19 @@ void CompiledMethod::clear_ic_callsites() {
   }
 }
 
+void CompiledMethod::clear_continuation_enter_special_inline_caches() {
+  assert (method()->is_continuation_enter_intrinsic(), "not Continuation.enterSpecial");
+
+  ResourceMark rm;
+  CompiledICLocker ml(this);
+  RelocIterator iter(this);
+  while(iter.next()) {
+    if (iter.type() == relocInfo::static_call_type) {
+      iter.reloc()->clear_inline_cache();
+    }
+  }
+}
+
 #ifdef ASSERT
 // Check class_loader is alive for this bit of metadata.
 class CheckClass : public MetadataClosure {

--- a/src/hotspot/share/code/compiledMethod.hpp
+++ b/src/hotspot/share/code/compiledMethod.hpp
@@ -374,6 +374,7 @@ public:
 
   virtual void clear_inline_caches();
   void clear_ic_callsites();
+  void clear_continuation_enter_special_inline_caches();
 
   // Execute nmethod barrier code, as if entering through nmethod call.
   void run_nmethod_entry_barrier();

--- a/src/hotspot/share/runtime/continuation.cpp
+++ b/src/hotspot/share/runtime/continuation.cpp
@@ -311,6 +311,9 @@ void Continuation::set_cont_fastpath_thread_state(JavaThread* thread) {
   assert(thread != nullptr, "");
   bool fast = !thread->is_interp_only_mode();
   thread->set_cont_fastpath_thread_state(fast);
+  if (thread->is_interp_only_mode() && ContinuationEntry::enter_special() != nullptr) {
+    ContinuationEntry::enter_special()->clear_continuation_enter_special_inline_caches();
+  }
 }
 
 void Continuation::notify_deopt(JavaThread* thread, intptr_t* sp) {

--- a/src/hotspot/share/runtime/continuationEntry.cpp
+++ b/src/hotspot/share/runtime/continuationEntry.cpp
@@ -34,10 +34,12 @@
 
 int ContinuationEntry::_return_pc_offset = 0;
 address ContinuationEntry::_return_pc = nullptr;
+CompiledMethod* ContinuationEntry::_enter_special = nullptr;
 
 void ContinuationEntry::set_enter_code(CompiledMethod* cm) {
   assert(_return_pc_offset != 0, "");
   _return_pc = cm->code_begin() + _return_pc_offset;
+  _enter_special = cm;
 }
 
 ContinuationEntry* ContinuationEntry::from_frame(const frame& f) {

--- a/src/hotspot/share/runtime/continuationEntry.hpp
+++ b/src/hotspot/share/runtime/continuationEntry.hpp
@@ -52,7 +52,8 @@ public:
 
 public:
   static int _return_pc_offset; // friend gen_continuation_enter
-  static void set_enter_code(CompiledMethod* nm); // friend SharedRuntime::generate_native_wrapper
+  static CompiledMethod* _enter_special;
+  static void set_enter_code(CompiledMethod* cm); // friend SharedRuntime::generate_native_wrapper
 
 private:
   static address _return_pc;
@@ -88,6 +89,8 @@ public:
   static address entry_pc() { return _return_pc; }
   intptr_t* entry_sp() const { return (intptr_t*)this; }
   intptr_t* entry_fp() const;
+
+  static CompiledMethod* enter_special() { return _enter_special; }
 
   int argsize() const { return _argsize; }
   void set_argsize(int value) { _argsize = value; }

--- a/src/hotspot/share/runtime/mutexLocker.cpp
+++ b/src/hotspot/share/runtime/mutexLocker.cpp
@@ -284,7 +284,7 @@ void mutex_init() {
   def(Heap_lock                    , PaddedMonitor, safepoint); // Doesn't safepoint check during termination.
   def(JfieldIdCreation_lock        , PaddedMutex  , safepoint);
 
-  def(CompiledIC_lock              , PaddedMutex  , nosafepoint);  // locks VtableStubs_lock, InlineCacheBuffer_lock
+  def(CompiledIC_lock              , PaddedMutex  , nosafepoint-1);  // locks VtableStubs_lock, InlineCacheBuffer_lock
   def(MethodCompileQueue_lock      , PaddedMonitor, safepoint);
   def(CompileStatistics_lock       , PaddedMutex  , safepoint);
   def(DirectivesStack_lock         , PaddedMutex  , nosafepoint);

--- a/test/hotspot/jtreg/ProblemList-Xcomp.txt
+++ b/test/hotspot/jtreg/ProblemList-Xcomp.txt
@@ -36,5 +36,3 @@ serviceability/sa/TestJhsdbJstackMixed.java 8248675 linux-aarch64
 vmTestbase/nsk/jvmti/scenarios/sampling/SP07/sp07t002/TestDescription.java 8245680 windows-x64
 
 vmTestbase/vm/mlvm/mixed/stress/regression/b6969574/INDIFY_Test.java 8265295 linux-x64,windows-x64
-
-serviceability/jvmti/vthread/ContStackDepthTest/ContStackDepthTest.java 8288949 generic-all


### PR DESCRIPTION
Please review the following bug fix:

`Continuation.enterSpecial` is a generated special nmethod (albeit not a Java method), with a well-known frame layout that calls `Continuation.enter`.

Because it is compiled, it resolves the call to `Continuation.enter` to its compiled version, if available. But this results in the compiled `Continuation.enter` being called even when the thread is in interp_only_mode.

This fix does three things:

1. When entering interp_only_mode, `Continuation::set_cont_fastpath_thread_state` will clear enterSpecial's resolved callsite to Continuation.enter.
2. In interp_only_mode, `SharedRuntime::resolve_static_call_C` will return `Continuation.enter`'s c2i entry rather than `verified_code_entry`.
3. In interp_only_mode, the c2i stub will not patch the callsite.

This fix isn't perfect, because a different thread, not in interp_only_mode, might patch the call. A longer-term solution is to create an "interpreted" version of `enterSpecial` and supporting an ad-hoc deoptimization. See https://bugs.openjdk.org/browse/JDK-8289128


Passes tiers 1-4 and Loom tiers 1-5.