### PR TITLE
8289093: BlockLocationPrinter fails to decode addresses with G1

### DIFF
--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2352,7 +2352,7 @@ HeapWord* G1CollectedHeap::block_start(const void* addr) const {
   // the heap. HeapRegion::block_start() has been optimized to not accept addresses
   // outside of the allocated area.
   if (addr >= hr->top()) {
-    return hr->top();
+    return nullptr;
   }
   return hr->block_start(addr);
 }

--- a/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
+++ b/src/hotspot/share/gc/g1/g1CollectedHeap.cpp
@@ -2348,6 +2348,12 @@ void G1CollectedHeap::par_iterate_regions_array(HeapRegionClosure* cl,
 
 HeapWord* G1CollectedHeap::block_start(const void* addr) const {
   HeapRegion* hr = heap_region_containing(addr);
+  // The CollectedHeap API requires us to not fail for any given address within
+  // the heap. HeapRegion::block_start() has been optimized to not accept addresses
+  // outside of the allocated area.
+  if (addr >= hr->top()) {
+    return hr->top();
+  }
   return hr->block_start(addr);
 }
 


### PR DESCRIPTION
Hi all,

  can I have reviews for this change that fixes an assertion failure when trying to add annotations to the hs_err file?

The `block_start` API from `CollectedHeap` assumes that useful values for all given addresses is returned, not asserting/crashing like some method deeper in the call chain does since [JDK-8270540](https://bugs.openjdk.org/browse/JDK-8270540), resulting in somewhat scrambled hs_err files and additional stack frames to look at in the debugger. 

Testing: local compilation, gha, tier1-3

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289093](https://bugs.openjdk.org/browse/JDK-8289093): BlockLocationPrinter fails to decode addresses with G1


### Reviewers
 * [Albert Mingkun Yang](https://openjdk.org/census#ayang) (@albertnetymk - **Reviewer**)
 * [Ivan Walulya](https://openjdk.org/census#iwalulya) (@walulyai - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/68/head:pull/68` \
`$ git checkout pull/68`

Update a local copy of the PR: \
`$ git checkout pull/68` \
`$ git pull https://git.openjdk.org/jdk19 pull/68/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 68`

View PR using the GUI difftool: \
`$ git pr show -t 68`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/68.diff">https://git.openjdk.org/jdk19/pull/68.diff</a>

</details>
