### PR TITLE
8289091: move oop safety check from SharedRuntime::get_java_tid() to JavaThread::threadObj()

### DIFF
--- a/src/hotspot/share/runtime/sharedRuntime.cpp
+++ b/src/hotspot/share/runtime/sharedRuntime.cpp
@@ -997,9 +997,6 @@ JRT_END
 
 jlong SharedRuntime::get_java_tid(Thread* thread) {
   if (thread != NULL && thread->is_Java_thread()) {
-    Thread* current = Thread::current();
-    guarantee(current != thread || JavaThread::cast(thread)->is_oop_safe(),
-              "current cannot touch oops after its GC barrier is detached.");
     oop obj = JavaThread::cast(thread)->threadObj();
     return (obj == NULL) ? 0 : java_lang_Thread::thread_id(obj);
   }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2215,11 +2215,13 @@ const char* JavaThread::name() const  {
 // descriptive string if there is no set name.
 const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {
   const char* name_str;
+#ifdef ASSERT
   Thread* current = Thread::current_or_null_safe();
   assert(current != nullptr, "cannot be called by a detached thread");
   if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
     // Only access threadObj() if current thread is not a JavaThread
     // or if it is a JavaThread that can safely access oops.
+#endif
     oop thread_obj = threadObj();
     if (thread_obj != NULL) {
       oop name = java_lang_Thread::name(thread_obj);
@@ -2237,6 +2239,7 @@ const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {
     } else {
       name_str = Thread::name();
     }
+#ifdef ASSERT
   } else {
     // Current JavaThread has exited...
     if (current == this) {
@@ -2248,6 +2251,7 @@ const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {
       name_str = Thread::name();
     }
   }
+#endif
   assert(name_str != NULL, "unexpected NULL thread name");
   return name_str;
 }

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -2147,11 +2147,10 @@ void JavaThread::print_name_on_error(outputStream* st, char *buf, int buflen) co
 // JavaThread::print() is that we can't grab lock or allocate memory.
 void JavaThread::print_on_error(outputStream* st, char *buf, int buflen) const {
   st->print("%s \"%s\"", type_name(), get_thread_name_string(buf, buflen));
-  Thread* current = Thread::current_or_null();
-  if (current != nullptr && (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe())) {
-    // Only access threadObj() if current thread is attached and
-    // if it is not a JavaThread or if it is a JavaThread that can safely
-    // access oops.
+  Thread* current = Thread::current();
+  if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
+    // Only access threadObj() if current thread is not a JavaThread
+    // or if it is a JavaThread that can safely access oops.
     oop thread_obj = threadObj();
     if (thread_obj != nullptr) {
       if (java_lang_Thread::is_daemon(thread_obj)) st->print(" daemon");
@@ -2214,12 +2213,8 @@ const char* JavaThread::name() const  {
 // descriptive string if there is no set name.
 const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {
   const char* name_str;
-  Thread* current = Thread::current_or_null();
-  if (current == nullptr) {
-    // Current thread is not attached so it can't safely determine this
-    // JavaThread's name so use the default thread name.
-    name_str = Thread::name();
-  } else if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
+  Thread* current = Thread::current();
+  if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
     // Only access threadObj() if current thread is not a JavaThread
     // or if it is a JavaThread that can safely access oops.
     oop thread_obj = threadObj();

--- a/src/hotspot/share/runtime/thread.cpp
+++ b/src/hotspot/share/runtime/thread.cpp
@@ -794,7 +794,8 @@ void JavaThread::set_threadOopHandles(oop p) {
 }
 
 oop JavaThread::threadObj() const {
-  Thread* current = Thread::current();
+  Thread* current = Thread::current_or_null_safe();
+  assert(current != nullptr, "cannot be called by a detached thread");
   guarantee(current != this || JavaThread::cast(current)->is_oop_safe(),
             "current cannot touch oops after its GC barrier is detached.");
   return _threadObj.resolve();
@@ -2147,7 +2148,8 @@ void JavaThread::print_name_on_error(outputStream* st, char *buf, int buflen) co
 // JavaThread::print() is that we can't grab lock or allocate memory.
 void JavaThread::print_on_error(outputStream* st, char *buf, int buflen) const {
   st->print("%s \"%s\"", type_name(), get_thread_name_string(buf, buflen));
-  Thread* current = Thread::current();
+  Thread* current = Thread::current_or_null_safe();
+  assert(current != nullptr, "cannot be called by a detached thread");
   if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
     // Only access threadObj() if current thread is not a JavaThread
     // or if it is a JavaThread that can safely access oops.
@@ -2213,7 +2215,8 @@ const char* JavaThread::name() const  {
 // descriptive string if there is no set name.
 const char* JavaThread::get_thread_name_string(char* buf, int buflen) const {
   const char* name_str;
-  Thread* current = Thread::current();
+  Thread* current = Thread::current_or_null_safe();
+  assert(current != nullptr, "cannot be called by a detached thread");
   if (!current->is_Java_thread() || JavaThread::cast(current)->is_oop_safe()) {
     // Only access threadObj() if current thread is not a JavaThread
     // or if it is a JavaThread that can safely access oops.


### PR DESCRIPTION
A trivial move of the oop safety check from SharedRuntime::get_java_tid() to
JavaThread::threadObj(). Also made adjustments to the threadObj() calls in
JavaThread::print_on_error() and JavaThread::get_thread_name_string() so
that we don't get secondary crashes when a JavaThread crashes after it has
detached the GC barrier.

Tested with Mach5 Tier[1-7]. A Mach5 Tier8 will be started this weekend.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289091](https://bugs.openjdk.org/browse/JDK-8289091): move oop safety check from SharedRuntime::get_java_tid() to JavaThread::threadObj()


### Reviewers
 * [Robbin Ehn](https://openjdk.org/census#rehn) (@robehn - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/69/head:pull/69` \
`$ git checkout pull/69`

Update a local copy of the PR: \
`$ git checkout pull/69` \
`$ git pull https://git.openjdk.org/jdk19 pull/69/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 69`

View PR using the GUI difftool: \
`$ git pr show -t 69`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/69.diff">https://git.openjdk.org/jdk19/pull/69.diff</a>

</details>
