### PR TITLE
JDK-8275784: Bogus warning generated for record with compact constructor

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -267,7 +267,7 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         return null;
     }
 
-    private  boolean isCanonicalRecordConstructor(ExecutableElement ee) {
+    private boolean isCanonicalRecordConstructor(ExecutableElement ee) {
         TypeElement te = (TypeElement) ee.getEnclosingElement();
         if (te.getKind() != ElementKind.RECORD) {
             return false;

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclint/Checker.java
@@ -33,6 +33,7 @@ import java.util.Deque;
 import java.util.EnumSet;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.Iterator;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.Map;
@@ -47,6 +48,7 @@ import javax.lang.model.element.ElementKind;
 import javax.lang.model.element.ExecutableElement;
 import javax.lang.model.element.Name;
 import javax.lang.model.element.NestingKind;
+import javax.lang.model.element.RecordComponentElement;
 import javax.lang.model.element.TypeElement;
 import javax.lang.model.element.VariableElement;
 import javax.lang.model.type.TypeKind;
@@ -244,8 +246,10 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         } else if (isExecutable()) {
             if (!isOverridingMethod) {
                 ExecutableElement ee = (ExecutableElement) env.currElement;
-                checkParamsDocumented(ee.getTypeParameters());
-                checkParamsDocumented(ee.getParameters());
+                if (!isCanonicalRecordConstructor(ee)) {
+                    checkParamsDocumented(ee.getTypeParameters());
+                    checkParamsDocumented(ee.getParameters());
+                }
                 switch (ee.getReturnType().getKind()) {
                     case VOID, NONE -> { }
                     default -> {
@@ -261,6 +265,31 @@ public class Checker extends DocTreePathScanner<Void, Void> {
         }
 
         return null;
+    }
+
+    private  boolean isCanonicalRecordConstructor(ExecutableElement ee) {
+        TypeElement te = (TypeElement) ee.getEnclosingElement();
+        if (te.getKind() != ElementKind.RECORD) {
+            return false;
+        }
+        List<? extends RecordComponentElement> stateComps = te.getRecordComponents();
+        List<? extends VariableElement> params = ee.getParameters();
+        if (stateComps.size() != params.size()) {
+            return false;
+        }
+
+        Iterator<? extends RecordComponentElement> stateIter = stateComps.iterator();
+        Iterator<? extends VariableElement> paramIter = params.iterator();
+        while (paramIter.hasNext() && stateIter.hasNext()) {
+            VariableElement param = paramIter.next();
+            RecordComponentElement comp = stateIter.next();
+            if (!Objects.equals(param.getSimpleName(), comp.getSimpleName())
+                    || !env.types.isSameType(param.asType(), comp.asType())) {
+                return false;
+            }
+        }
+
+        return true;
     }
 
     private void reportMissing(String code, Object... args) {

--- a/test/langtools/tools/doclint/RecordCompactConstructorTest.java
+++ b/test/langtools/tools/doclint/RecordCompactConstructorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test /nodynamiccopyright/
+ * @bug 8275784
+ * @summary Bogus warning generated for record with compact constructor
+ * @modules jdk.javadoc/jdk.javadoc.internal.doclint
+ * @build DocLintTester
+ * @run main DocLintTester -Xmsgs:all RecordCompactConstructorTest.java
+ */
+
+/**
+ * Comment.
+ * @param a aaa
+ * @param b bbb
+ * @param c ccc
+ */
+public record RecordCompactConstructorTest(int a, int b, int c) {
+    /** Compact constructor. */
+    public RecordCompactConstructorTest { }
+}


### PR DESCRIPTION
Please review a simple change to disable the check for missing `@param` tags in the case of a compact constructor for a record. In this case, there is no explicit argument list: it is inferred from the  list of record components, and so there is no need to check for `@param` tags.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8275784](https://bugs.openjdk.org/browse/JDK-8275784): Bogus warning generated for record with compact constructor


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/70/head:pull/70` \
`$ git checkout pull/70`

Update a local copy of the PR: \
`$ git checkout pull/70` \
`$ git pull https://git.openjdk.org/jdk19 pull/70/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 70`

View PR using the GUI difftool: \
`$ git pr show -t 70`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/70.diff">https://git.openjdk.org/jdk19/pull/70.diff</a>

</details>
