### PR TITLE
8289079: java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 failed with "RuntimeException: Test failed"

### DIFF
--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/AttachTest.java
@@ -63,8 +63,6 @@ public class AttachTest {
                 .executeTestJava(opts)
                 .outputTo(System.out)
                 .errorTo(System.out);
-        int exitValue = outputAnalyzer.getExitValue();
-        if (exitValue != 0)
-            throw new RuntimeException("Test failed");
+        outputAnalyzer.shouldHaveExitValue(0);
     }
 }

--- a/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
+++ b/test/jdk/java/lang/Thread/jni/AttachCurrentThread/ImplicitAttach.java
@@ -52,7 +52,7 @@ public class ImplicitAttach {
                 .findStatic(ImplicitAttach.class, "callback", MethodType.methodType(void.class));
         MemorySegment upcallStub = abi.upcallStub(callback,
                 FunctionDescriptor.ofVoid(),
-                MemorySession.openImplicit());
+                MemorySession.global());
 
         // void start_threads(int count, void *(*f)(void *))
         SymbolLookup symbolLookup = SymbolLookup.loaderLookup();


### PR DESCRIPTION
This is a fix to a recently added test. The test uses pthread_create to create native threads that invoke a Java method via a generated "upcall stub". The upcall stub is created in an implicit memory session but the test doesn't do anything to ensure that the memory session remains open. Testing in higher tiers runs the test with options that sometimes lead to a cleaner closing the memory session before the native threads have terminated. The failure mode is exit code 133 due to a child VM exiting with SIGTRAP. The test needs to be changed to ensure that the memory session is not closed until the threads terminate. To keep it simple, I've changed it to use the global memory session. The alternative is to change it to use a shared session or a reachability fence, coupled with a pthread_join to ensure that all native threads with a reference to stub terminate before the session is closed. The test is intended to exercise concurrent implicit attaching so keeping it as simple as possible seems best.

The test is also changed too use shouldHaveExitValue(0) as the original test discarded the child VM exit code when the test failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289079](https://bugs.openjdk.org/browse/JDK-8289079): java/lang/Thread/jni/AttachCurrentThread/AttachTest.java#id1 failed with "RuntimeException: Test failed"


### Reviewers
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Maurizio Cimadamore](https://openjdk.org/census#mcimadamore) (@mcimadamore - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/73/head:pull/73` \
`$ git checkout pull/73`

Update a local copy of the PR: \
`$ git checkout pull/73` \
`$ git pull https://git.openjdk.org/jdk19 pull/73/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 73`

View PR using the GUI difftool: \
`$ git pr show -t 73`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/73.diff">https://git.openjdk.org/jdk19/pull/73.diff</a>

</details>
