### PR TITLE
8289228: SegmentAllocator::allocateArray null handling is too lax

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -285,9 +285,11 @@ public interface SegmentAllocator {
         Objects.requireNonNull(array);
         Objects.requireNonNull(elementLayout);
         int size = Array.getLength(array);
-        MemorySegment addr = allocate(MemoryLayout.sequenceLayout(size, elementLayout));
-        MemorySegment.copy(heapSegmentFactory.apply(array), elementLayout, 0,
-                addr, elementLayout.withOrder(ByteOrder.nativeOrder()), 0, size);
+        MemorySegment addr = allocateArray(elementLayout, size);
+        if (size > 0) {
+            MemorySegment.copy(heapSegmentFactory.apply(array), elementLayout, 0,
+                    addr, elementLayout.withOrder(ByteOrder.nativeOrder()), 0, size);
+        }
         return addr;
     }
 

--- a/test/jdk/java/foreign/TestNulls.java
+++ b/test/jdk/java/foreign/TestNulls.java
@@ -121,21 +121,7 @@ public class TestNulls {
             "java.lang.foreign.ValueLayout$OfLong/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "java.lang.foreign.ValueLayout$OfDouble/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
             "java.lang.foreign.GroupLayout/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
-            "java.lang.foreign.FunctionDescriptor/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfByte,byte[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfShort,short[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfChar,char[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfInt,int[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfFloat,float[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfLong,long[])/1/0",
-            "java.lang.foreign.SegmentAllocator/allocateArray(java.lang.foreign.ValueLayout$OfDouble,double[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfByte,byte[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfShort,short[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfChar,char[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfInt,int[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfFloat,float[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfLong,long[])/1/0",
-            "java.lang.foreign.MemorySession/allocateArray(java.lang.foreign.ValueLayout$OfDouble,double[])/1/0"
+            "java.lang.foreign.FunctionDescriptor/withAttribute(java.lang.String,java.lang.constant.Constable)/1/0"
     );
 
     static final Set<String> OBJECT_METHODS = Stream.of(Object.class.getMethods())


### PR DESCRIPTION
Recent fix for JDK-8289188 relaxed behavior or `SegmentAllocator::allocateArray` too much w.r.t. nulls. This patch reverts null handling to what it used to be.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289228](https://bugs.openjdk.org/browse/JDK-8289228): SegmentAllocator::allocateArray null handling is too lax


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/76/head:pull/76` \
`$ git checkout pull/76`

Update a local copy of the PR: \
`$ git checkout pull/76` \
`$ git pull https://git.openjdk.org/jdk19 pull/76/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 76`

View PR using the GUI difftool: \
`$ git pr show -t 76`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/76.diff">https://git.openjdk.org/jdk19/pull/76.diff</a>

</details>
