### PR TITLE
8289235: ProblemList vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java when run with vthread wrapper

### DIFF
--- a/test/hotspot/jtreg/ProblemList-svc-vthread.txt
+++ b/test/hotspot/jtreg/ProblemList-svc-vthread.txt
@@ -96,6 +96,8 @@ vmTestbase/nsk/jdb/repeat/repeat001/repeat001.java
 ####
 ## NSK JDI tests failing with wrapper
 
+vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java 8282379 generic-all
+
 ####
 ## The test expects an NPE to be uncaught, but nsk.share.MainWrapper
 ## introduces exception handlers.


### PR DESCRIPTION
A trivial fix to ProblemList vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java
when run with vthread wrapper.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289235](https://bugs.openjdk.org/browse/JDK-8289235): ProblemList vmTestbase/nsk/jdi/ClassType/invokeMethod/invokemethod011/TestDescription.java when run with vthread wrapper


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/77/head:pull/77` \
`$ git checkout pull/77`

Update a local copy of the PR: \
`$ git checkout pull/77` \
`$ git pull https://git.openjdk.org/jdk19 pull/77/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 77`

View PR using the GUI difftool: \
`$ git pr show -t 77`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/77.diff">https://git.openjdk.org/jdk19/pull/77.diff</a>

</details>
