### PR TITLE
8289240: ProblemList java/lang/reflect/callerCache/ReflectionCallerCacheTest.java in -Xcomp mode

### DIFF
--- a/test/jdk/ProblemList-Xcomp.txt
+++ b/test/jdk/ProblemList-Xcomp.txt
@@ -30,4 +30,4 @@
 java/lang/invoke/MethodHandles/CatchExceptionTest.java 8146623 generic-all
 java/lang/ref/ReferenceEnqueue.java 8284236 generic-all
 java/lang/ref/OOMEInReferenceHandler.java 8066859 generic-all
-java/lang/reflect/callerCache/ReflectionCallerCacheTest.java 8288286 macosx-x64,windows-x64
+java/lang/reflect/callerCache/ReflectionCallerCacheTest.java 8288286 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList java/lang/reflect/callerCache/ReflectionCallerCacheTest.java in -Xcomp mode.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289240](https://bugs.openjdk.org/browse/JDK-8289240): ProblemList java/lang/reflect/callerCache/ReflectionCallerCacheTest.java in -Xcomp mode


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/78/head:pull/78` \
`$ git checkout pull/78`

Update a local copy of the PR: \
`$ git checkout pull/78` \
`$ git pull https://git.openjdk.org/jdk19 pull/78/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 78`

View PR using the GUI difftool: \
`$ git pr show -t 78`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/78.diff">https://git.openjdk.org/jdk19/pull/78.diff</a>

</details>
