### PR TITLE
8288836: (fs) Files.writeString spec for IOException has "specified charset" when no charset is provided

### DIFF
--- a/src/java.base/share/classes/java/nio/file/Files.java
+++ b/src/java.base/share/classes/java/nio/file/Files.java
@@ -3654,7 +3654,7 @@ public final class Files {
      *          if {@code options} contains an invalid combination of options
      * @throws  IOException
      *          if an I/O error occurs writing to or creating the file, or the
-     *          text cannot be encoded using the specified charset
+     *          text cannot be encoded using UTF-8
      * @throws  UnsupportedOperationException
      *          if an unsupported option is specified
      * @throws  SecurityException


### PR DESCRIPTION
Change "specified charset" to "UTF-8" in specification of `IOException` thrown by `Files.writeString(Path path, CharSequence csq, OpenOption... options)`.