### PR TITLE
8288854: getLocalGraphicsEnvironment() on for multi-screen setups throws exception NPE

### DIFF
--- a/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
+++ b/src/java.desktop/unix/classes/sun/awt/X11GraphicsEnvironment.java
@@ -236,7 +236,7 @@ public final class X11GraphicsEnvironment extends SunGraphicsEnvironment {
             throw new AWTError("no screen devices");
         }
         int index = getDefaultScreenNum();
-        mainScreen = 0 < index && index < screens.length ? index : 0;
+        mainScreen = 0 < index && index < numScreens ? index : 0;
 
         for (int id = 0; id < numScreens; ++id) {
             devices.put(id, old.containsKey(id) ? old.remove(id) :


### PR DESCRIPTION
This is the fix for a copy-paste error. The fix JDK-8076313 replaced the usage of the "screens" array from the parent class to the "devices" where the list of devices is now maintained. Since "screens" array is never used nor initialized its usage caused an NPE. That check was copied as-is, while it should use the actual number of screen devices requested early in that method.

The bug is rarely reproduced because in single screen configuration the main screen is usually 0, and in the multiscreen configuration Xinerama is usually active so the main screen is also 0 => the second part of the "if" statement is not executed.

I have validated the fix by the SwingSet, I also executed desktop tests in that config and found that even though this particular bug is fixed we still have many issues there, around ~100 tests failed.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288854](https://bugs.openjdk.org/browse/JDK-8288854): getLocalGraphicsEnvironment() on for multi-screen setups throws exception NPE


### Reviewers
 * [Alexander Zvegintsev](https://openjdk.org/census#azvegint) (@azvegint - **Reviewer**)
 * [Alexey Ivanov](https://openjdk.org/census#aivanov) (@aivanov-jdk - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/81/head:pull/81` \
`$ git checkout pull/81`

Update a local copy of the PR: \
`$ git checkout pull/81` \
`$ git pull https://git.openjdk.org/jdk19 pull/81/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 81`

View PR using the GUI difftool: \
`$ git pr show -t 81`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/81.diff">https://git.openjdk.org/jdk19/pull/81.diff</a>

</details>
