### PR TITLE
8289278: Suspend/ResumeAllVirtualThreads need both can_suspend and can_support_virtual_threads 

### DIFF
--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -1743,7 +1743,7 @@ jvmtiEnv *jvmti;
       <origin>new</origin>
       <capabilities>
         <required id="can_suspend"></required>
-        <required id="can_support_virtual_threads"></required>
+        <required id="can_support_virtual_threads">Can support virtual threads</required>
       </capabilities>
       <parameters>
         <param id="except_count">
@@ -1871,7 +1871,7 @@ jvmtiEnv *jvmti;
       <origin>new</origin>
       <capabilities>
         <required id="can_suspend"></required>
-        <required id="can_support_virtual_threads"></required>
+        <required id="can_support_virtual_threads">Can support virtual threads</required>
       </capabilities>
       <parameters>
         <param id="except_count">
@@ -10606,10 +10606,12 @@ myInit() {
           permanent features of the Java platform.</i>
           <p/>
           Can support virtual threads.
-          See <functionlink id="SuspendAllVirtualThreads"/>,
-          <functionlink id="ResumeAllVirtualThreads"/>,
-          <eventlink id="VirtualThreadStart"/>,
-          and <eventlink id="VirtualThreadEnd"/>.
+          If this capability is enabled then the following functions can be called:
+          <functionlink id="SuspendAllVirtualThreads"></functionlink>,
+          <functionlink id="ResumeAllVirtualThreads"></functionlink>,
+          and the following events can be enabled:
+          <eventlink id="VirtualThreadStart"></eventlink>,
+          <eventlink id="VirtualThreadEnd"></eventlink>.
         </description>
       </capabilityfield>
     </capabilitiestypedef>

--- a/src/hotspot/share/prims/jvmti.xml
+++ b/src/hotspot/share/prims/jvmti.xml
@@ -10606,12 +10606,10 @@ myInit() {
           permanent features of the Java platform.</i>
           <p/>
           Can support virtual threads.
-          If this capability is enabled then the following functions can be called:
-          <functionlink id="SuspendAllVirtualThreads"></functionlink>,
-          <functionlink id="ResumeAllVirtualThreads"></functionlink>,
-          and the following events can be enabled:
-          <eventlink id="VirtualThreadStart"></eventlink>,
-          <eventlink id="VirtualThreadEnd"></eventlink>,
+          See <functionlink id="SuspendAllVirtualThreads"/>,
+          <functionlink id="ResumeAllVirtualThreads"/>,
+          <eventlink id="VirtualThreadStart"/>,
+          and <eventlink id="VirtualThreadEnd"/>.
         </description>
       </capabilityfield>
     </capabilitiestypedef>

--- a/src/hotspot/share/prims/jvmti.xsl
+++ b/src/hotspot/share/prims/jvmti.xsl
@@ -1104,7 +1104,7 @@ typedef struct {
                     The following capability
                   </xsl:when>
                   <xsl:otherwise>
-                    One of the following capabilities
+                    The following capabilities
                   </xsl:otherwise>
                 </xsl:choose>
                 (as returned by <a href="#GetCapabilities"><code>GetCapabilities</code></a>)


### PR DESCRIPTION
This is spec only change to the JVM TI spec. The `SuspendAllVirtualThreads` and `ResumeAllVirtualThreads` functions added in Java 19 currently specify that they require one of the capabilities `can_suspend` or `can_support_virtual_threads`. This is not correct as both capabilities are required.

The issue is in the XSL used to generate the spec, and specifically the `capabilities` template where it emits different text when the number of required capabilities is not 0 or 1. Additionally, the description of the `can_support_virtual_threads` is overridden in both functions to avoid making it appear that the capability on its own is needed to use these functions.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8289278](https://bugs.openjdk.org/browse/JDK-8289278): Suspend/ResumeAllVirtualThreads need both can_suspend and can_support_virtual_threads
 * [JDK-8289287](https://bugs.openjdk.org/browse/JDK-8289287): Suspend/ResumeAllVirtualThreads need both can_suspend and can_support_virtual_threads (**CSR**)


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Daniel D. Daugherty](https://openjdk.org/census#dcubed) (@dcubed-ojdk - **Reviewer**)
 * [David Holmes](https://openjdk.org/census#dholmes) (@dholmes-ora - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/82/head:pull/82` \
`$ git checkout pull/82`

Update a local copy of the PR: \
`$ git checkout pull/82` \
`$ git pull https://git.openjdk.org/jdk19 pull/82/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 82`

View PR using the GUI difftool: \
`$ git pr show -t 82`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/82.diff">https://git.openjdk.org/jdk19/pull/82.diff</a>

</details>
