### PR TITLE
8289252: Recommend Locale.of() method instead of the constructor

### DIFF
--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2605,8 +2605,8 @@ public final class Locale implements Cloneable, Serializable {
      *
      * <p>The following example shows how to obtain a {@code Locale} object
      * using a {@code Builder}.
-     * {@snippet :
-     *     Locale aLocale = new Locale.Builder().setLanguage("sr").setScript("Latn").setRegion("RS").build();
+     * {@snippet lang=java :
+     * Locale aLocale = new Locale.Builder().setLanguage("sr").setScript("Latn").setRegion("RS").build();
      * }
      *
      * <p>Builders can be reused; {@code clear()} resets all

--- a/src/java.base/share/classes/java/util/Locale.java
+++ b/src/java.base/share/classes/java/util/Locale.java
@@ -2585,34 +2585,35 @@ public final class Locale implements Cloneable, Serializable {
     /**
      * {@code Builder} is used to build instances of {@code Locale}
      * from values configured by the setters.  Unlike the {@code Locale}
-     * constructors, the {@code Builder} checks if a value configured by a
+     * constructors or {@code Locale.of()} factory methods,
+     * the {@code Builder} checks if a value configured by a
      * setter satisfies the syntax requirements defined by the {@code Locale}
      * class.  A {@code Locale} object obtained from a {@code Builder} is
      * well-formed and can be transformed to a well-formed IETF BCP 47 language tag
      * without losing information.
      *
-     * <p><b>Note:</b> The {@code Locale} class does not provide any
+     * @implNote
+     * The {@code Locale} class does not provide any
      * syntactic restrictions on variant, while BCP 47 requires each variant
      * subtag to be 5 to 8 alphanumerics or a single numeric followed by 3
      * alphanumerics.  The method {@code setVariant} throws
      * {@code IllformedLocaleException} for a variant that does not satisfy
-     * this restriction. If it is necessary to support such a variant, use a
-     * Locale constructor.  However, keep in mind that a {@code Locale}
+     * this restriction. If it is necessary to support such a variant, use
+     * {@link Locale#of(String, String, String)}.  However, keep in mind that a {@code Locale}
      * object obtained this way might lose the variant information when
      * transformed to a BCP 47 language tag.
      *
      * <p>The following example shows how to obtain a {@code Locale} object
      * using a {@code Builder}.
-     * <blockquote>
-     * <pre>
-     *     Locale aLocale = new Builder().setLanguage("sr").setScript("Latn").setRegion("RS").build();
-     * </pre>
-     * </blockquote>
+     * {@snippet :
+     *     Locale aLocale = new Locale.Builder().setLanguage("sr").setScript("Latn").setRegion("RS").build();
+     * }
      *
      * <p>Builders can be reused; {@code clear()} resets all
      * fields to their default values.
      *
      * @see Locale#forLanguageTag
+     * @see Locale#of(String, String, String)
      * @since 1.7
      */
     public static final class Builder {
@@ -2763,11 +2764,12 @@ public final class Locale implements Cloneable, Serializable {
          * the {@code Locale} class does not impose any syntactic
          * restriction on variant, and the variant value in
          * {@code Locale} is case sensitive.  To set such a variant,
-         * use a Locale constructor.
+         * use {@link Locale#of(String, String, String)}.
          *
          * @param variant the variant
          * @return This builder.
          * @throws IllformedLocaleException if {@code variant} is ill-formed
+         * @see Locale#of(String, String, String)
          */
         public Builder setVariant(String variant) {
             try {


### PR DESCRIPTION
This is a leftover documentation fix to the deprecation of `Locale` constructors. `Locale.Builder` class had some texts that suggested using one of those constructors, which need to be replaced with a `Locale.of()` method. A corresponding CSR has also been drafted.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8289252](https://bugs.openjdk.org/browse/JDK-8289252): Recommend Locale.of() method instead of the constructor
 * [JDK-8289254](https://bugs.openjdk.org/browse/JDK-8289254): Recommend Locale.of() method instead of the constructor (**CSR**)


### Reviewers
 * [Joe Wang](https://openjdk.org/census#joehw) (@JoeWang-Java - **Reviewer**) ⚠️ Review applies to [258aff4e](https://git.openjdk.org/jdk19/pull/85/files/258aff4e5ade88b6c56c39944d7c3b9a34dcdc9b)
 * [Roger Riggs](https://openjdk.org/census#rriggs) (@RogerRiggs - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/85/head:pull/85` \
`$ git checkout pull/85`

Update a local copy of the PR: \
`$ git checkout pull/85` \
`$ git pull https://git.openjdk.org/jdk19 pull/85/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 85`

View PR using the GUI difftool: \
`$ git pr show -t 85`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/85.diff">https://git.openjdk.org/jdk19/pull/85.diff</a>

</details>
