### PR TITLE
8287847: Fatal Error when suspending virtual thread after it has terminated

### DIFF
--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -413,10 +413,10 @@ insertThread(JNIEnv *env, ThreadList *list, jthread thread)
                 EXIT_ERROR(error, "getting vthread state");
             }
             if ((vthread_state & JVMTI_THREAD_STATE_ALIVE) == 0) {
-              // Thread not alive so put on otherThreads list instead of runningVThreads.
-              // It might not have started yet or might have terminated. Either way,
-              // otherThreads is the place for it.
-              list = &otherThreads;
+                // Thread not alive so put on otherThreads list instead of runningVThreads.
+                // It might not have started yet or might have terminated. Either way,
+                // otherThreads is the place for it.
+                list = &otherThreads;
             }
             if (suspendAllCount > 0) {
                 // Assume the suspendAllCount, just like the regular thread case above.

--- a/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
+++ b/src/jdk.jdwp.agent/share/native/libjdwp/threadControl.c
@@ -412,6 +412,12 @@ insertThread(JNIEnv *env, ThreadList *list, jthread thread)
             if (error != JVMTI_ERROR_NONE) {
                 EXIT_ERROR(error, "getting vthread state");
             }
+            if ((vthread_state & JVMTI_THREAD_STATE_ALIVE) == 0) {
+              // Thread not alive so put on otherThreads list instead of runningVThreads.
+              // It might not have started yet or might have terminated. Either way,
+              // otherThreads is the place for it.
+              list = &otherThreads;
+            }
             if (suspendAllCount > 0) {
                 // Assume the suspendAllCount, just like the regular thread case above.
                 node->suspendCount = suspendAllCount;
@@ -419,7 +425,6 @@ insertThread(JNIEnv *env, ThreadList *list, jthread thread)
                     // If state == 0, then this is a new vthread that has not been started yet.
                     // Need to suspendOnStart in that case, just like the regular thread case above.
                     node->suspendOnStart = JNI_TRUE;
-                    list = &otherThreads; // Put on otherThreads list instead of runningVThreads
                 }
             }
             if (vthread_state != 0) {

--- a/test/jdk/TEST.groups
+++ b/test/jdk/TEST.groups
@@ -494,6 +494,7 @@ jdk_jdi_sanity = \
     com/sun/jdi/ResumeOneThreadTest.java \
     com/sun/jdi/RunToExit.java \
     com/sun/jdi/SourceNameFilterTest.java \
+    com/sun/jdi/SuspendAfterDeath.java \
     com/sun/jdi/VarargsTest.java \
     com/sun/jdi/Vars.java \
     com/sun/jdi/redefineMethod/RedefineTest.java \

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -59,7 +59,7 @@ class SuspendAfterDeathTarg {
 
 public class SuspendAfterDeath extends TestScaffold {
     private volatile ThreadReference thread;
-    private volatile boolean breakpointReached = false;
+    private volatile boolean breakpointReached;
 
     SuspendAfterDeath(String args[]) {
         super(args);

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -94,9 +94,9 @@ public class SuspendAfterDeath extends TestScaffold {
     public void connect(String args[]) {
         String mainWrapper = System.getProperty("main.wrapper");
         if ("Virtual".equals(mainWrapper)) {
-            List argList = new ArrayList(Arrays.asList(args));
+            List<String> argList = new ArrayList(Arrays.asList(args));
             argList.add("Virtual");
-            args = (String[]) argList.toArray(args);
+            args = argList.toArray(args);
         }
         super.connect(args);
     }

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -36,7 +36,6 @@ import com.sun.jdi.event.*;
 import com.sun.jdi.request.*;
 import java.util.*;
 
-
 class SuspendAfterDeathTarg {
     static final String THREAD_NAME = "duke";
 
@@ -61,7 +60,7 @@ class SuspendAfterDeathTarg {
 public class SuspendAfterDeath extends TestScaffold {
     private volatile ThreadReference thread;
     private volatile boolean breakpointReached = false;
-    
+
     SuspendAfterDeath(String args[]) {
         super(args);
     }
@@ -85,7 +84,7 @@ public class SuspendAfterDeath extends TestScaffold {
         System.out.println("Breakpoint, thread=" + eventThread);
         if (thread == null) {
             failure("FAILED: got Breakpoint event before ThreadDeath event.");
-        }            
+        }
         breakpointReached = true;
         /* Suspend the thread. This is being done after the thread has exited. */
         thread.suspend();

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -1,0 +1,136 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8287847
+ * @summary Test suspending a thread after it has terminated.
+ * @enablePreview
+ * @requires vm.continuations
+ * @run build TestScaffold VMConnection TargetListener TargetAdapter
+ * @run compile SuspendAfterDeath.java
+ * @run main/othervm SuspendAfterDeath
+ */
+import com.sun.jdi.*;
+import com.sun.jdi.event.*;
+import com.sun.jdi.request.*;
+import java.util.*;
+
+
+class SuspendAfterDeathTarg {
+    static final String THREAD_NAME = "duke";
+
+    // breakpoint here
+    static void done() {
+    }
+
+    public static void main(String[] args) throws Exception {
+        boolean useVirtualThread = ((args.length > 0) && args[0].equals("Virtual"));
+        Thread thread;
+        System.out.println("Starting debuggee " + (useVirtualThread ? "virtual" : "platform") + " thread.");
+        if (useVirtualThread) {
+            thread = Thread.ofVirtual().name(THREAD_NAME).start(() -> { });
+        } else {
+            thread = Thread.ofPlatform().name(THREAD_NAME).start(() -> { });
+        }
+        thread.join();
+        done();
+    }
+}
+
+public class SuspendAfterDeath extends TestScaffold {
+    private volatile ThreadReference thread;
+    private volatile boolean breakpointReached = false;
+    
+    SuspendAfterDeath(String args[]) {
+        super(args);
+    }
+
+    public static void main(String[] args) throws Exception {
+        new SuspendAfterDeath(args).startTests();
+    }
+
+    @Override
+    public void threadDied(ThreadDeathEvent event) {
+        ThreadReference eventThread = event.thread();
+        if (eventThread.name().equals(SuspendAfterDeathTarg.THREAD_NAME)) {
+            System.out.println("Target thread died, thread=" + eventThread);
+            thread = eventThread;
+        }
+    }
+
+    @Override
+    public void breakpointReached(BreakpointEvent event) {
+        ThreadReference eventThread = event.thread();
+        System.out.println("Breakpoint, thread=" + eventThread);
+        if (thread == null) {
+            failure("FAILED: got Breakpoint event before ThreadDeath event.");
+        }            
+        breakpointReached = true;
+        /* Suspend the thread. This is being done after the thread has exited. */
+        thread.suspend();
+    }
+
+    @Override
+    public void connect(String args[]) {
+        String mainWrapper = System.getProperty("main.wrapper");
+        if ("Virtual".equals(mainWrapper)) {
+            List argList = new ArrayList(Arrays.asList(args));
+            argList.add("Virtual");
+            args = (String[]) argList.toArray(args);
+        }
+        super.connect(args);
+    }
+
+    @Override
+    protected void runTests() throws Exception {
+        BreakpointEvent bpe = startToMain("SuspendAfterDeathTarg");
+        EventRequestManager erm = vm().eventRequestManager();
+
+        // listener for ThreadDeathEvent captures reference to the thread
+        ThreadDeathRequest request1 = erm.createThreadDeathRequest();
+        request1.enable();
+
+        // listener for BreakpointEvent attempts to suspend the thread
+        ReferenceType targetClass = bpe.location().declaringType();
+        Location loc = findMethod(targetClass, "done", "()V").location();
+        BreakpointRequest request2 = erm.createBreakpointRequest(loc);
+        request2.setSuspendPolicy(EventRequest.SUSPEND_EVENT_THREAD);
+        request2.enable();
+
+        listenUntilVMDisconnect();
+
+        if (thread == null) {
+            failure("FAILED: never got ThreadDeath event for target thread.");
+        }
+        if (!breakpointReached) {
+            failure("FAILED: never got Breakpoint event for target thread.");
+        }
+
+        if (!testFailed) {
+            println("SuspendAfterDeath: passed");
+        } else {
+            throw new Exception("SuspendAfterDeath: failed");
+        }
+    }
+}

--- a/test/jdk/com/sun/jdi/SuspendAfterDeath.java
+++ b/test/jdk/com/sun/jdi/SuspendAfterDeath.java
@@ -24,7 +24,7 @@
 /**
  * @test id=platform_thread
  * @bug 8287847
- * @summary Test suspending a thread after it has terminated.
+ * @summary Test suspending a platform thread after it has terminated.
  * @enablePreview
  * @requires vm.continuations
  * @run build TestScaffold VMConnection TargetListener TargetAdapter
@@ -35,7 +35,7 @@
 /**
  * @test id=virtual_thread
  * @bug 8287847
- * @summary Test suspending a thread after it has terminated.
+ * @summary Test suspending a virtual thread after it has terminated.
  * @enablePreview
  * @requires vm.continuations
  * @run build TestScaffold VMConnection TargetListener TargetAdapter

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -66,6 +66,7 @@ abstract public class TestScaffold extends TargetAdapter {
     final String[] args;
     protected boolean testFailed = false;
     protected long startTime;
+    public static final String OLD_MAIN_THREAD_NAME = "old-m-a-i-n";
 
     static private class ArgInfo {
         String targetVMArgs = "";
@@ -460,6 +461,9 @@ abstract public class TestScaffold extends TargetAdapter {
         String mainWrapper = System.getProperty("main.wrapper");
         if ("Virtual".equals(mainWrapper)) {
             argInfo.targetAppCommandLine = TestScaffold.class.getName() + " " + mainWrapper + " ";
+            argInfo.targetVMArgs += "--enable-preview ";
+        } else if ("true".equals(System.getProperty("test.enable.preview"))) {
+            // the test specified @enablePreview.
             argInfo.targetVMArgs += "--enable-preview ";
         }
 
@@ -969,6 +973,8 @@ abstract public class TestScaffold extends TargetAdapter {
                     tg.uncaughtThrowable = error;
                 }
             });
+            Thread.currentThread().setName(OLD_MAIN_THREAD_NAME);
+            vthread.setName("main");
             vthread.join();
         } else if (wrapper.equals("Kernel")) {
             MainThreadGroup tg = new MainThreadGroup();

--- a/test/jdk/com/sun/jdi/TestScaffold.java
+++ b/test/jdk/com/sun/jdi/TestScaffold.java
@@ -360,10 +360,10 @@ abstract public class TestScaffold extends TargetAdapter {
     }
 
     protected void startUp(String targetName) {
-        List argList = new ArrayList(Arrays.asList(args));
+        List<String> argList = new ArrayList(Arrays.asList(args));
         argList.add(targetName);
         println("run args: " + argList);
-        connect((String[]) argList.toArray(args));
+        connect(argList.toArray(args));
         waitForVMStart();
     }
 


### PR DESCRIPTION
This fixes a bug in the debug agent when there is a request to suspend a virtual thread that has already terminated. The issue was that unless the debug agent was currently under a "suspend all", it would not properly put the virtual thread on the `otherThreads` list, and instead added it to `runningVThreads`. This meant at the end of `insertThread()` the following code tried to do a JVMTI `SetThreadLocalStorage`, which can't be done on a terminated thread.

```
        if (list != &otherThreads) {
            setThreadLocalStorage(node->thread, (void*)node);
        }
```

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287847](https://bugs.openjdk.org/browse/JDK-8287847): Fatal Error when suspending virtual thread after it has terminated


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**) ⚠️ Review applies to [1ff59060](https://git.openjdk.org/jdk19/pull/88/files/1ff59060b9f0b50ceb83a6e36195c707a09f41c2)
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/88/head:pull/88` \
`$ git checkout pull/88`

Update a local copy of the PR: \
`$ git checkout pull/88` \
`$ git pull https://git.openjdk.org/jdk19 pull/88/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 88`

View PR using the GUI difftool: \
`$ git pr show -t 88`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/88.diff">https://git.openjdk.org/jdk19/pull/88.diff</a>

</details>
