### PR TITLE
8289183: jdk.jfr.consumer.RecordedThread.getId references Thread::getId, should be Thread::threadId

### DIFF
--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -54,7 +54,7 @@ public final class RecordedThread extends RecordedObject {
     /**
      * Returns the thread ID used by the operating system.
      *
-     * @return The OS thread ID, or {@code -1} if doesn't exist
+     * @return the OS thread ID, or {@code -1} if doesn't exist
      */
     public long getOSThreadId() {
         Long l = getTyped("osThreadId", Long.class, -1L);

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -99,7 +99,10 @@ public final class RecordedThread extends RecordedObject {
      * reused within the lifespan of the JVM.
      * <p>
      * See {@link #getJavaThreadId()} for the ID that is returned by
-     * {@code java.lang.Thread.threadId()}
+     * {@code java.lang.Thread.threadId()}.
+     * <p>
+     * See {@link #getOSThreadId()} for the ID that is returned by
+     * the operating system.
      *
      * @return a unique ID for the thread
      */

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -54,7 +54,7 @@ public final class RecordedThread extends RecordedObject {
     /**
      * Returns the thread ID used by the operating system.
      *
-     * @return The Java thread ID, or {@code -1} if doesn't exist
+     * @return The OS thread ID, or {@code -1} if doesn't exist
      */
     public long getOSThreadId() {
         Long l = getTyped("osThreadId", Long.class, -1L);
@@ -97,7 +97,7 @@ public final class RecordedThread extends RecordedObject {
      * reused within the lifespan of the JVM.
      * <p>
      * See {@link #getJavaThreadId()} for the ID that is returned by
-     * {@code java.lang.Thread.getId()}
+     * {@code java.lang.Thread.threadId()}
      *
      * @return a unique ID for the thread
      */

--- a/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
+++ b/src/jdk.jfr/share/classes/jdk/jfr/consumer/RecordedThread.java
@@ -86,6 +86,8 @@ public final class RecordedThread extends RecordedObject {
      * Returns the Java thread ID, or {@code -1} if it's not a Java thread.
      *
      * @return the Java thread ID, or {@code -1} if it's not a Java thread
+     *
+     * @see java.lang.Thread#threadId()
      */
     public long getJavaThreadId() {
         Long l = getTyped("javaThreadId", Long.class, -1L);


### PR DESCRIPTION
Could I have a review of PR  that changes documentation from the now deprecated method Thread.getId() to the new Thread.threadId().

I also fixed a typo, where it said "The Java thread". Should be "the OS thread".

Testing:  'make docs' and inspect the result

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289183](https://bugs.openjdk.org/browse/JDK-8289183): jdk.jfr.consumer.RecordedThread.getId references Thread::getId, should be Thread::threadId


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/93/head:pull/93` \
`$ git checkout pull/93`

Update a local copy of the PR: \
`$ git checkout pull/93` \
`$ git pull https://git.openjdk.org/jdk19 pull/93/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 93`

View PR using the GUI difftool: \
`$ git pr show -t 93`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/93.diff">https://git.openjdk.org/jdk19/pull/93.diff</a>

</details>
