### PR TITLE
8067757: Incorrect HTML generation for copied javadoc with multiple @throws tags

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/formats/html/TagletWriterImpl.java
@@ -504,7 +504,7 @@ public class TagletWriterImpl extends TagletWriter {
            excName = htmlWriter.getLink(new HtmlLinkInfo(configuration, HtmlLinkInfo.Kind.MEMBER,
                    substituteType));
         } else if (exception == null) {
-            excName = new RawHtml(ch.getExceptionName(throwsTag).toString());
+            excName = new RawHtml(throwsTag.getExceptionName().toString());
         } else if (exception.asType() == null) {
             excName = new RawHtml(utils.getFullyQualifiedName(exception));
         } else {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -147,7 +147,11 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
      *
      * @param throwsTags        the collection of tags to be converted
      * @param writer            the taglet-writer used by the doclet
-     * @param alreadyDocumented the set of exceptions that have already been documented
+     * @param alreadyDocumented the set of exceptions that have already been
+     *                          documented and thus must not be documented by
+     *                          this method. All exceptions documented by this
+     *                          method will be added to this set upon the
+     *                          method's return.
      * @return the generated content for the tags
      */
     protected Content throwsTagsOutput(Map<List<ThrowsTree>, ExecutableElement> throwsTags,

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -48,9 +48,7 @@ import com.sun.source.doctree.ThrowsTree;
 
 import jdk.javadoc.doclet.Taglet.Location;
 import jdk.javadoc.internal.doclets.toolkit.Content;
-import jdk.javadoc.internal.doclets.toolkit.util.CommentHelper;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFinder;
-import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
  * A taglet that processes {@link ThrowsTree}, which represents
@@ -64,9 +62,9 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     public void inherit(DocFinder.Input input, DocFinder.Output output) {
-        Utils utils = input.utils;
+        var utils = input.utils;
         Element target;
-        CommentHelper ch = utils.getCommentHelper(input.element);
+        var ch = utils.getCommentHelper(input.element);
         if (input.tagId == null) {
             var tag = (ThrowsTree) input.docTreeInfo.docTree();
             target = ch.getException(tag);
@@ -97,13 +95,13 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
 
     @Override
     public Content getAllBlockTagOutput(Element holder, TagletWriter writer) {
-        Utils utils = writer.configuration().utils;
+        var utils = writer.configuration().utils;
         var executable = (ExecutableElement) holder;
         ExecutableType instantiatedType = utils.asInstantiatedMethodType(
                 writer.getCurrentPageElement(), executable);
         List<? extends TypeMirror> thrownTypes = instantiatedType.getThrownTypes();
         Map<String, TypeMirror> typeSubstitutions = getSubstitutedThrownTypes(
-                writer.configuration().utils.typeUtils,
+                utils.typeUtils,
                 executable.getThrownTypes(),
                 thrownTypes);
         Map<ThrowsTree, ExecutableElement> tagsMap = new LinkedHashMap<>();
@@ -159,12 +157,12 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                                        TagletWriter writer,
                                        Set<String> alreadyDocumented,
                                        Map<String, TypeMirror> typeSubstitutions) {
-        Utils utils = writer.configuration().utils;
+        var utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         var documentedInThisCall = new HashSet<String>();
         for (Entry<ThrowsTree, ExecutableElement> entry : throwsTags.entrySet()) {
             Element e = entry.getValue();
-            CommentHelper ch = utils.getCommentHelper(e);
+            var ch = utils.getCommentHelper(e);
             ThrowsTree tag = entry.getKey();
             Element te = ch.getException(tag);
             String excName = tag.getExceptionName().toString();
@@ -208,7 +206,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             assert holder.getKind() == ElementKind.CONSTRUCTOR : holder.getKind();
             return result;
         }
-        Utils utils = writer.configuration().utils;
+        var utils = writer.configuration().utils;
         Map<ThrowsTree, ExecutableElement> declaredExceptionTags = new LinkedHashMap<>();
         for (TypeMirror declaredExceptionType : declaredExceptionTypes) {
             var input = new DocFinder.Input(utils, holder, this,
@@ -236,7 +234,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                                                          Set<String> alreadyDocumented,
                                                          TagletWriter writer) {
         // TODO: assert declaredExceptionTypes are instantiated
-        Utils utils = writer.configuration().utils;
+        var utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         for (TypeMirror declaredExceptionType : declaredExceptionTypes) {
             TypeElement te = utils.asTypeElement(declaredExceptionType);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -153,10 +153,10 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
      *                          method's return.
      * @return the generated content for the tags
      */
-    protected Content throwsTagsOutput(Map<ThrowsTree, ExecutableElement> throwsTags,
-                                       TagletWriter writer,
-                                       Set<String> alreadyDocumented,
-                                       Map<String, TypeMirror> typeSubstitutions) {
+    private Content throwsTagsOutput(Map<ThrowsTree, ExecutableElement> throwsTags,
+                                     TagletWriter writer,
+                                     Set<String> alreadyDocumented,
+                                     Map<String, TypeMirror> typeSubstitutions) {
         var utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         var documentedInThisCall = new HashSet<String>();

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -168,9 +168,9 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                 Element te = ch.getException(tag);
                 String excName = tag.getExceptionName().toString();
                 TypeMirror substituteType = typeSubstitutions.get(excName);
-                if ((alreadyDocumented.contains(excName) ||
-                                (te != null && alreadyDocumented.contains(utils.getFullyQualifiedName(te, false)))) ||
-                        (substituteType != null && alreadyDocumented.contains(substituteType.toString()))) {
+                if (alreadyDocumented.contains(excName)
+                        || (te != null && alreadyDocumented.contains(utils.getFullyQualifiedName(te, false)))
+                        || (substituteType != null && alreadyDocumented.contains(substituteType.toString()))) {
                     continue;
                 }
                 if (alreadyDocumented.isEmpty() && documentedInThisCall.isEmpty()) {

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -108,7 +108,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         utils.getThrowsTrees(executable).forEach(t -> tagsMap.put(t, executable));
         Content result = writer.getOutputInstance();
         Set<String> alreadyDocumented = new HashSet<>();
-        result.add(throwsTagsOutput(tagsMap, writer, alreadyDocumented, typeSubstitutions));
+        result.add(throwsTagsOutput(tagsMap, alreadyDocumented, typeSubstitutions, writer));
         result.add(inheritThrowsDocumentation(executable, thrownTypes, alreadyDocumented, typeSubstitutions, writer));
         result.add(linkToUndocumentedDeclaredExceptions(thrownTypes, alreadyDocumented, writer));
         return result;
@@ -145,18 +145,18 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
      *
      * @param throwsTags        the tags to be converted; each tag is mapped to
      *                          a method it appears on
-     * @param writer            the taglet-writer used by the doclet
      * @param alreadyDocumented the set of exceptions that have already been
      *                          documented and thus must not be documented by
      *                          this method. All exceptions documented by this
      *                          method will be added to this set upon the
      *                          method's return.
+     * @param writer            the taglet-writer used by the doclet
      * @return the generated content for the tags
      */
     private Content throwsTagsOutput(Map<ThrowsTree, ExecutableElement> throwsTags,
-                                     TagletWriter writer,
                                      Set<String> alreadyDocumented,
-                                     Map<String, TypeMirror> typeSubstitutions) {
+                                     Map<String, TypeMirror> typeSubstitutions,
+                                     TagletWriter writer) {
         var utils = writer.configuration().utils;
         Content result = writer.getOutputInstance();
         var documentedInThisCall = new HashSet<String>();
@@ -225,8 +225,8 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                 inheritedDoc.tagList.forEach(t -> declaredExceptionTags.put((ThrowsTree) t, h));
             }
         }
-        result.add(throwsTagsOutput(declaredExceptionTags, writer, alreadyDocumented,
-                typeSubstitutions));
+        result.add(throwsTagsOutput(declaredExceptionTags, alreadyDocumented, typeSubstitutions,
+                writer));
         return result;
     }
 

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -71,7 +71,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             var tag = (ThrowsTree) input.docTreeInfo.docTree();
             target = ch.getException(tag);
             input.tagId = target == null
-                    ? ch.getExceptionName(tag).getSignature()
+                    ? tag.getExceptionName().getSignature()
                     : utils.getFullyQualifiedName(target);
         } else {
             target = input.utils.findClass(input.element, input.tagId);
@@ -166,7 +166,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             CommentHelper ch = utils.getCommentHelper(e);
             for (ThrowsTree tag : entry.getKey()) {
                 Element te = ch.getException(tag);
-                String excName = ch.getExceptionName(tag).toString();
+                String excName = tag.getExceptionName().toString();
                 TypeMirror substituteType = typeSubstitutions.get(excName);
                 if ((alreadyDocumented.contains(excName) ||
                                 (te != null && alreadyDocumented.contains(utils.getFullyQualifiedName(te, false)))) ||

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -145,7 +145,8 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     /**
      * Returns the generated content for a collection of {@code @throws} tags.
      *
-     * @param throwsTags        the collection of tags to be converted
+     * @param throwsTags        the tags to be converted; each tag is mapped to
+     *                          a method it appears on
      * @param writer            the taglet-writer used by the doclet
      * @param alreadyDocumented the set of exceptions that have already been
      *                          documented and thus must not be documented by

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/util/CommentHelper.java
@@ -547,10 +547,6 @@ public class CommentHelper {
         return dtree.getKind() == SEE ? ((SeeTree)dtree).getReference() : null;
     }
 
-    public ReferenceTree getExceptionName(ThrowsTree tt) {
-        return tt.getExceptionName();
-    }
-
     public IdentifierTree getName(DocTree dtree) {
         switch (dtree.getKind()) {
             case PARAM:

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritance/TestThrowsTagInheritance.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritance/TestThrowsTagInheritance.java
@@ -69,7 +69,7 @@ public class TestThrowsTagInheritance extends JavadocTester {
         checkExit(Exit.OK);
 
         // The method should not inherit the IOOBE throws tag from the abstract class,
-        // for now keep keep this bug compatible, should fix this correctly in
+        // for now keep this bug compatible, should fix this correctly in
         // the future.
         checkOutput("pkg/Extender.html", false, "java.lang.IndexOutOfBoundsException");
     }

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -305,4 +305,49 @@ public class TestOneToMany extends JavadocTester {
                 <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if that</dd>
                 </dl>""");
     }
+
+    @Test
+    public void testSubExceptionDoubleInheritance(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyException extends Exception { }
+                """, """
+                package x;
+
+                public class MySubException extends MyException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyException if this
+                     * @throws MySubException if that
+                     */
+                    void m() throws MyException, MySubException;
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    @Override
+                    void m() throws MyException, MySubException;
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyException.html" title="class in x">MyException</a></code> - if this</dd>
+                <dd><code><a href="MySubException.html" title="class in x">MySubException</a></code> - if that</dd>
+                </dl>""");
+    }
 }

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -1,0 +1,308 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8067757
+ * @library /tools/lib ../../lib
+ * @modules jdk.compiler/com.sun.tools.javac.api
+ *          jdk.compiler/com.sun.tools.javac.main
+ *          jdk.javadoc/jdk.javadoc.internal.tool
+ * @build toolbox.ToolBox javadoc.tester.*
+ * @run main TestOneToMany
+ */
+
+import javadoc.tester.JavadocTester;
+import toolbox.ToolBox;
+
+import java.nio.file.Path;
+import java.nio.file.Paths;
+
+public class TestOneToMany extends JavadocTester {
+
+    public static void main(String... args) throws Exception {
+        var tester = new TestOneToMany();
+        tester.runTests(m -> new Object[]{Paths.get(m.getName())});
+    }
+
+    private final ToolBox tb = new ToolBox();
+
+    // These tests:
+    //
+    //   - Use own exceptions to not depend on platform links or a setup with
+    //     the no-platform-links option
+    //   - Enclose files in a package to exercise a typical source layout and
+    //     avoid enumerating separate files in the javadoc command
+
+    @Test
+    public void testUncheckedException(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyRuntimeException extends RuntimeException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    void m();
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    @Override
+                    void m() throws MyRuntimeException;
+                }
+                """, """
+                package x;
+
+                public class IImpl implements I {
+
+                    @Override
+                    public void m() throws MyRuntimeException { }
+                }
+                """, """
+                package x;
+
+                public class C {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    public void m();
+                }
+                """, """
+                package x;
+
+                public class C1 extends C {
+
+                    @Override
+                    public void m() throws MyRuntimeException { }
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/IImpl.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/C1.html", true, """
+                <dl class="notes">
+                <dt>Overrides:</dt>
+                <dd><code><a href="C.html#m()">m</a></code>&nbsp;in class&nbsp;<code><a href="C.html" title="class in x">C</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+    }
+
+    @Test
+    public void testUncheckedExceptionWithRedundantThrows(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyRuntimeException extends RuntimeException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    void m() throws MyRuntimeException;
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    @Override
+                    void m() throws MyRuntimeException;
+                }
+                """, """
+                package x;
+
+                public class IImpl implements I {
+
+                    @Override
+                    public void m() throws MyRuntimeException { }
+                }
+                """, """
+                package x;
+
+                public class C {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    public void m() throws MyRuntimeException;
+                }
+                """, """
+                package x;
+
+                public class C1 extends C {
+
+                    @Override
+                    public void m() throws MyRuntimeException { }
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/IImpl.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/C1.html", true, """
+                <dl class="notes">
+                <dt>Overrides:</dt>
+                <dd><code><a href="C.html#m()">m</a></code>&nbsp;in class&nbsp;<code><a href="C.html" title="class in x">C</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+    }
+
+    @Test
+    public void testCheckedException(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyCheckedException extends Exception { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyCheckedException if this
+                     * @throws MyCheckedException if that
+                     */
+                    void m() throws MyCheckedException;
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    @Override
+                    void m() throws MyCheckedException;
+                }
+                """, """
+                package x;
+
+                public class IImpl implements I {
+
+                    @Override
+                    public void m() throws MyCheckedException { }
+                }
+                """, """
+                package x;
+
+                public class C {
+
+                    /**
+                     * @throws MyCheckedException if this
+                     * @throws MyCheckedException if that
+                     */
+                    public void m()  throws MyCheckedException;
+                }
+                """, """
+                package x;
+
+                public class C1 extends C {
+
+                    @Override
+                    public void m() throws MyCheckedException { }
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/IImpl.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if this</dd>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if this</dd>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/C1.html", true, """
+                <dl class="notes">
+                <dt>Overrides:</dt>
+                <dd><code><a href="C.html#m()">m</a></code>&nbsp;in class&nbsp;<code><a href="C.html" title="class in x">C</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if this</dd>
+                <dd><code><a href="MyCheckedException.html" title="class in x">MyCheckedException</a></code> - if that</dd>
+                </dl>""");
+    }
+}


### PR DESCRIPTION
Please review this PR for JDK 19.

This PR fixes JDK-8067757. To understand what JDK-8067757 is about, you first need to understand how javadoc documents the fact that such and such exceptions are thrown by a constructor or method.

If a constructor or method declaration indicates thrown exceptions, javadoc creates the "Throws:" section in that declaration documentation. Here's the algorithm which javadoc uses to fill in that section:

1. For each `@throws` tag that is directly present on the declaration, add an entry to the section.
2. If this is a method declaration, then for those exceptions from that declaration's `throws` clause for which there were no `@throws` tags found in step 1, try to inherit `@throws` tags from the overridden methods found as per Method Comments Algorithm[^1].
3. For each of the remaining exceptions from the `throws` clause (i.e. the exceptions for which documentation could neither be found in step 1, nor inherited in step 2), add an entry that mentions the exception but has no description. 

The problem that JDK-8067757 is concerned with is that if an exception is documented using multiple `@throws` tags, only one of these tags will be inherited in step 2.

While fixing this issue I discovered an unpleasant interference with JDK-4947455[^2] and fixed it.

Looking ahead, JDK-6509045[^3] is about a similar problem that happens in step 1 in the presence of `{@inheritDoc}`. I'm also planning to fix JDK-6509045 in JDK 19.

[^1]: https://docs.oracle.com/en/java/javase/18/docs/specs/javadoc/doc-comment-spec.html#method-comments-algorithm
[^2]: https://bugs.openjdk.org/browse/JDK-4947455
[^3]: https://bugs.openjdk.org/browse/JDK-6509045

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8067757](https://bugs.openjdk.org/browse/JDK-8067757): Incorrect HTML generation for copied javadoc with multiple @throws tags


### Reviewers
 * [Jonathan Gibbons](https://openjdk.org/census#jjg) (@jonathan-gibbons - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/95/head:pull/95` \
`$ git checkout pull/95`

Update a local copy of the PR: \
`$ git checkout pull/95` \
`$ git pull https://git.openjdk.org/jdk19 pull/95/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 95`

View PR using the GUI difftool: \
`$ git pr show -t 95`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/95.diff">https://git.openjdk.org/jdk19/pull/95.diff</a>

</details>
