### PR TITLE
8289549: ISO 4217 Amendment 172 Update

### DIFF
--- a/src/java.base/share/data/currency/CurrencyData.properties
+++ b/src/java.base/share/data/currency/CurrencyData.properties
@@ -32,7 +32,7 @@ formatVersion=3
 # Version of the currency code information in this class.
 # It is a serial number that accompanies with each amendment.
 
-dataVersion=171
+dataVersion=172
 
 # List of all valid ISO 4217 currency codes.
 # To ensure compatibility, do not remove codes.

--- a/test/jdk/java/util/Currency/tablea1.txt
+++ b/test/jdk/java/util/Currency/tablea1.txt
@@ -1,12 +1,12 @@
 #
 #
-# Amendments up until ISO 4217 AMENDMENT NUMBER 171
-#   (As of 16 Mar 2022)
+# Amendments up until ISO 4217 AMENDMENT NUMBER 172
+#   (As of 27 June 2022)
 #
 
 # Version
 FILEVERSION=3
-DATAVERSION=171
+DATAVERSION=172
 
 # ISO 4217 currency data
 AF	AFN	971	2


### PR DESCRIPTION
Trivial fix to currency data files. The change was only made to its amendment number, as the new Sierra Leone currency has already been active with amendment 171.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289549](https://bugs.openjdk.org/browse/JDK-8289549): ISO 4217 Amendment 172 Update


### Reviewers
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/96/head:pull/96` \
`$ git checkout pull/96`

Update a local copy of the PR: \
`$ git checkout pull/96` \
`$ git pull https://git.openjdk.org/jdk19 pull/96/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 96`

View PR using the GUI difftool: \
`$ git pr show -t 96`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/96.diff">https://git.openjdk.org/jdk19/pull/96.diff</a>

</details>
