### PR TITLE
8289558: Need spec clarification of j.l.foreign.*Layout

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
@@ -120,6 +120,9 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
         return this instanceof PaddingLayout;
     }
 
+    // the following methods have to copy the same Javadoc as in MemoryLayout, or subclasses will just show
+    // the Object methods javadoc
+
     /**
      * {@return the hash code value for this layout}
      */
@@ -134,7 +137,8 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
      * the same kind, have the same size, name and alignment constraints. Furthermore, depending on the layout kind, additional
      * conditions must be satisfied:
      * <ul>
-     *     <li>two value layouts are considered equal if they have the same byte order (see {@link ValueLayout#order()})</li>
+     *     <li>two value layouts are considered equal if they have the same {@linkplain ValueLayout#order() order},
+     *     and {@linkplain ValueLayout#carrier() carrier}</li>
      *     <li>two sequence layouts are considered equal if they have the same element count (see {@link SequenceLayout#elementCount()}), and
      *     if their element layouts (see {@link SequenceLayout#elementLayout()}) are also equal</li>
      *     <li>two group layouts are considered equal if they are of the same kind (see {@link GroupLayout#isStruct()},
@@ -155,6 +159,7 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
         }
 
         return Objects.equals(name, ((AbstractLayout) that).name) &&
+                Objects.equals(size, ((AbstractLayout)that).size) &&
                 Objects.equals(alignment, ((AbstractLayout) that).alignment);
     }
 

--- a/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/AbstractLayout.java
@@ -128,7 +128,7 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
      */
     @Override
     public int hashCode() {
-        return name.hashCode() << Long.hashCode(alignment);
+        return Objects.hash(name, size, alignment);
     }
 
     /**
@@ -145,22 +145,19 @@ abstract non-sealed class AbstractLayout implements MemoryLayout {
      *     {@link GroupLayout#isUnion()}) and if their member layouts (see {@link GroupLayout#memberLayouts()}) are also equal</li>
      * </ul>
      *
-     * @param that the object to be compared for equality with this layout.
+     * @param other the object to be compared for equality with this layout.
      * @return {@code true} if the specified object is equal to this layout.
      */
     @Override
-    public boolean equals(Object that) {
-        if (this == that) {
+    public boolean equals(Object other) {
+        if (this == other) {
             return true;
         }
 
-        if (!(that instanceof AbstractLayout)) {
-            return false;
-        }
-
-        return Objects.equals(name, ((AbstractLayout) that).name) &&
-                Objects.equals(size, ((AbstractLayout)that).size) &&
-                Objects.equals(alignment, ((AbstractLayout) that).alignment);
+        return other instanceof AbstractLayout otherLayout &&
+                name.equals(otherLayout.name) &&
+                size == otherLayout.size &&
+                alignment == otherLayout.alignment;
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/GroupLayout.java
@@ -143,10 +143,9 @@ public final class GroupLayout extends AbstractLayout implements MemoryLayout {
         if (!super.equals(other)) {
             return false;
         }
-        if (!(other instanceof GroupLayout g)) {
-            return false;
-        }
-        return kind.equals(g.kind) && elements.equals(g.elements);
+        return other instanceof GroupLayout otherGroup &&
+                kind == otherGroup.kind &&
+                elements.equals(otherGroup.elements);
     }
 
     /**

--- a/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryLayout.java
@@ -584,17 +584,18 @@ public sealed interface MemoryLayout permits AbstractLayout, SequenceLayout, Gro
      * the same kind, have the same size, name and alignment constraints. Furthermore, depending on the layout kind, additional
      * conditions must be satisfied:
      * <ul>
-     *     <li>two value layouts are considered equal if they have the same byte order (see {@link ValueLayout#order()})</li>
+     *     <li>two value layouts are considered equal if they have the same {@linkplain ValueLayout#order() order},
+     *     and {@linkplain ValueLayout#carrier() carrier}</li>
      *     <li>two sequence layouts are considered equal if they have the same element count (see {@link SequenceLayout#elementCount()}), and
      *     if their element layouts (see {@link SequenceLayout#elementLayout()}) are also equal</li>
      *     <li>two group layouts are considered equal if they are of the same kind (see {@link GroupLayout#isStruct()},
      *     {@link GroupLayout#isUnion()}) and if their member layouts (see {@link GroupLayout#memberLayouts()}) are also equal</li>
      * </ul>
      *
-     * @param that the object to be compared for equality with this layout.
+     * @param other the object to be compared for equality with this layout.
      * @return {@code true} if the specified object is equal to this layout.
      */
-    boolean equals(Object that);
+    boolean equals(Object other);
 
     /**
      * {@return the hash code value for this layout}

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -211,10 +211,9 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
         if (!super.equals(other)) {
             return false;
         }
-        if (!(other instanceof SequenceLayout s)) {
-            return false;
-        }
-        return elemCount == s.elemCount && elementLayout.equals(s.elementLayout);
+        return other instanceof SequenceLayout otherSeq &&
+                elemCount == otherSeq.elemCount &&
+                elementLayout.equals(otherSeq.elementLayout);
     }
 
     @Override

--- a/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/SequenceLayout.java
@@ -124,7 +124,6 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
      * @param elementCounts an array of element counts, of which at most one can be {@code -1}.
      * @return a sequence layout where element layouts in the flattened projection of this
      * sequence layout (see {@link #flatten()}) are re-arranged into one or more nested sequence layouts.
-     * @throws UnsupportedOperationException if this sequence layout does not have an element count.
      * @throws IllegalArgumentException if two or more element counts are set to {@code -1}, or if one
      * or more element count is {@code <= 0} (but other than {@code -1}) or, if, after any required inference,
      * multiplying the element counts does not yield the same element count as the flattened projection of this
@@ -187,8 +186,6 @@ public final class SequenceLayout extends AbstractLayout implements MemoryLayout
      * }
      * @return a sequence layout with the same size as this layout (but, possibly, with different
      * element count), whose element layout is not a sequence layout.
-     * @throws UnsupportedOperationException if this sequence layout, or one of the nested sequence layouts being
-     * flattened, does not have an element count.
      */
     public SequenceLayout flatten() {
         long count = elementCount();

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -93,6 +93,9 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
         return new ValueLayout(carrier, Objects.requireNonNull(order), bitSize(), alignment, name());
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public String toString() {
         char descriptor = carrier == MemoryAddress.class ? 'A' : carrier.descriptorString().charAt(0);
@@ -102,6 +105,9 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
         return decorateLayoutString(String.format("%s%d", descriptor, bitSize()));
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public boolean equals(Object other) {
         if (this == other) {
@@ -114,9 +120,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
             return false;
         }
         return carrier.equals(v.carrier) &&
-            order.equals(v.order) &&
-            bitSize() == v.bitSize() &&
-            alignment == v.alignment;
+            order.equals(v.order);
     }
 
     /**
@@ -171,7 +175,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
      * @return a var handle which can be used to dereference a multi-dimensional array, featuring {@code shape.length + 1}
      * {@code long} coordinates.
      * @throws IllegalArgumentException if {@code shape[i] < 0}, for at least one index {@code i}.
-     * @throws UnsupportedOperationException if the layout path has one or more elements with incompatible alignment constraints.
+     * @throws UnsupportedOperationException if {@code bitAlignment() > bitSize()}.
      * @see MethodHandles#memorySegmentViewVarHandle
      * @see MemoryLayout#varHandle(PathElement...)
      * @see SequenceLayout
@@ -198,6 +202,9 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
         return carrier;
     }
 
+    /**
+     * {@inheritDoc}
+     */
     @Override
     public int hashCode() {
         return Objects.hash(super.hashCode(), order, bitSize(), alignment);

--- a/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
+++ b/src/java.base/share/classes/java/lang/foreign/ValueLayout.java
@@ -116,11 +116,9 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
         if (!super.equals(other)) {
             return false;
         }
-        if (!(other instanceof ValueLayout v)) {
-            return false;
-        }
-        return carrier.equals(v.carrier) &&
-            order.equals(v.order);
+        return other instanceof ValueLayout otherValue &&
+                carrier.equals(otherValue.carrier) &&
+                order.equals(otherValue.order);
     }
 
     /**
@@ -207,7 +205,7 @@ public sealed class ValueLayout extends AbstractLayout implements MemoryLayout {
      */
     @Override
     public int hashCode() {
-        return Objects.hash(super.hashCode(), order, bitSize(), alignment);
+        return Objects.hash(super.hashCode(), order, carrier);
     }
 
     @Override


### PR DESCRIPTION
This patch fixes few javadoc issues in the memory layout API.
The main issues are that `SequenceLayout::flatten` and `SequenceLayout::reshape` still mention failures caused by a lack of size. But that condition is no longer possible in the new API.

The javadoc of `ValueLayout::arrayElementVarHandle` is suboptimal and can be clarified - UOE is only thrown if the value layout alignment is bigger than its size.

Finally, the `MemoryLayout::equals` method does not mention value layout carriers.

The JBS issue associated with this PR mentions also other issues, mostly related to the overly broad visibility of some of the methods in the javadoc (e.g. isPadding). Unfortunately, given the presence of an intermediate, non-public, abstract class, this is what we get from javadoc. Fixing these issues would require a deeper restructuring of the implementation, which would be too riskt at this stage.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue
- [x] Change requires a CSR request to be approved

### Issues
 * [JDK-8289558](https://bugs.openjdk.org/browse/JDK-8289558): Need spec clarification of j.l.foreign.*Layout
 * [JDK-8289577](https://bugs.openjdk.org/browse/JDK-8289577): Need spec clarification of j.l.foreign.*Layout (**CSR**)


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/98/head:pull/98` \
`$ git checkout pull/98`

Update a local copy of the PR: \
`$ git checkout pull/98` \
`$ git pull https://git.openjdk.org/jdk19 pull/98/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 98`

View PR using the GUI difftool: \
`$ git pr show -t 98`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/98.diff">https://git.openjdk.org/jdk19/pull/98.diff</a>

</details>
