### PR TITLE
8289570: SegmentAllocator:allocateUtf8String(String str) default behavior mismatch to spec

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -146,7 +146,7 @@ public final class Utils {
     }
 
     public static MemorySegment toCString(byte[] bytes, SegmentAllocator allocator) {
-        MemorySegment addr = allocator.allocate(bytes.length + 1, 1L);
+        MemorySegment addr = allocator.allocate(bytes.length + 1);
         copy(addr, bytes);
         return addr;
     }

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -185,6 +185,25 @@ public class TestSegmentAllocators {
         assertEquals(calls.get(), 7);
     }
 
+    @Test
+    public void testStringAllocateDelegation() {
+        AtomicInteger calls = new AtomicInteger();
+        SegmentAllocator allocator = new SegmentAllocator() {
+            @Override
+            public MemorySegment allocate(long bytesSize, long bytesAlignment) {
+                return MemorySegment.allocateNative(bytesSize, bytesAlignment, MemorySession.openImplicit());
+            }
+
+            @Override
+            public MemorySegment allocate(long size) {
+                calls.incrementAndGet();
+                return allocate(size, 1);
+            };
+        };
+        allocator.allocateUtf8String("Hello");
+        assertEquals(calls.get(), 1);
+    }
+
 
     @Test(dataProvider = "arrayAllocations")
     public <Z> void testArray(AllocationFactory allocationFactory, ValueLayout layout, AllocationFunction<Object, ValueLayout> allocationFunction, ToArrayHelper<Z> arrayHelper) {


### PR DESCRIPTION
This simple patch fixes an issue where the API implementation for `SegmentAllocator::allocateUtf8String` does not conform to the javadoc implSpec.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289570](https://bugs.openjdk.org/browse/JDK-8289570): SegmentAllocator:allocateUtf8String(String str) default behavior mismatch to spec


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/99/head:pull/99` \
`$ git checkout pull/99`

Update a local copy of the PR: \
`$ git checkout pull/99` \
`$ git pull https://git.openjdk.org/jdk19 pull/99/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 99`

View PR using the GUI difftool: \
`$ git pr show -t 99`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/99.diff">https://git.openjdk.org/jdk19/pull/99.diff</a>

</details>
