### PR TITLE
8289585: ProblemList sun/tools/jhsdb/JStackStressTest.java on linux-aarch64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -739,6 +739,8 @@ sun/tools/jstat/jstatLineCounts2.sh                             8268211 linux-aa
 sun/tools/jstat/jstatLineCounts3.sh                             8268211 linux-aarch64
 sun/tools/jstat/jstatLineCounts4.sh                             8268211 linux-aarch64
 
+sun/tools/jhsdb/JStackStressTest.java                           8276210 linux-aarch64
+
 ############################################################################
 
 # jdk_other


### PR DESCRIPTION
A trivial fix to  ProblemList sun/tools/jhsdb/JStackStressTest.java on linux-aarch64.