### PR TITLE
8288703: GetThreadState returns 0 for virtual thread that has terminated

### DIFF
--- a/src/hotspot/share/prims/jvmtiEnvBase.cpp
+++ b/src/hotspot/share/prims/jvmtiEnvBase.cpp
@@ -1320,12 +1320,12 @@ JvmtiEnvBase::get_threadOop_and_JavaThread(ThreadsList* t_list, jthread thread,
       java_thread = get_JavaThread_or_null(thread_oop);
     }
   }
+  *jt_pp = java_thread;
+  *thread_oop_p = thread_oop;
   if (java_lang_VirtualThread::is_instance(thread_oop) &&
       !JvmtiEnvBase::is_vthread_alive(thread_oop)) {
     return JVMTI_ERROR_THREAD_NOT_ALIVE;
   }
-  *jt_pp = java_thread;
-  *thread_oop_p = thread_oop;
   return JVMTI_ERROR_NONE;
 }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/thread/GetThreadState/thrstat03/thrstat03.java
@@ -87,7 +87,7 @@ public class thrstat03 {
             throw new Error("Unexpected: " + e);
         }
 
-        if (!check(t, t.isVirtual() ? NOT_STARTED : ZOMBIE)) {
+        if (!check(t, ZOMBIE)) {
             throw new RuntimeException();
         }
     }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
@@ -36,12 +36,18 @@ public class SelfSuspendDisablerTest {
         System.loadLibrary("SelfSuspendDisablerTest");
     }
 
+    // Tested JVM TI thread states
+    static final int NEW        = 0;        // No bits are set
+    static final int TERMINATED = 2;        // JVMTI_THREAD_STATE_TERMINATED
+    static final int RUNNABLE   = 5;        // JVMTI_THREAD_STATE_ALIVE & JVMTI_THREAD_STATE_RUNNABLE
+    static final int SUSPENDED  = 0x100005; // RUNNABLE & JVMTI_THREAD_STATE_SUSPENDED
+
     native static boolean isSuspended(Thread thread);
     native static void selfSuspend();
     native static void resume(Thread thread);
     native static void suspendAllVirtualThreads();
     native static void resumeAllVirtualThreads();
-
+    native static int getThreadState(Thread thread);
 
     private static void sleep(long millis) {
         try {
@@ -51,26 +57,57 @@ public class SelfSuspendDisablerTest {
         }
     }
 
+    private static void testJvmtiThreadState(Thread thread, int expectedState) throws RuntimeException {
+        String kindStr = thread.isVirtual()? "virtual " : "platform";
+        int state = getThreadState(thread);
+
+        System.out.printf("Expected %s thread state: %06X got: %06X\n",
+                          kindStr, expectedState, state);
+        if (state != expectedState) {
+            throw new RuntimeException("Test FAILED: Unexpected thread state"); 
+        }
+    }
+
     public static void main(String argv[]) throws Exception {
-        Thread t1 = Thread.ofPlatform().start(() -> {
+        Thread t1 = Thread.ofPlatform().factory().newThread(() -> {
+            testJvmtiThreadState(Thread.currentThread(), RUNNABLE);
             selfSuspend();
         });
-        Thread t2 = Thread.ofVirtual().start(() -> {
+        Thread t2 = Thread.ofVirtual().factory().newThread(() -> {
+            testJvmtiThreadState(Thread.currentThread(), RUNNABLE);
             while(!isSuspended(t1)) {
               Thread.yield();
             }
             Thread.yield(); // provoke unmount
+
+            testJvmtiThreadState(t1, SUSPENDED);
+
             resume(t1);
+
+            testJvmtiThreadState(t1, RUNNABLE);
+
             suspendAllVirtualThreads();
         });
+
+        testJvmtiThreadState(t1, NEW);
+        testJvmtiThreadState(t2, NEW);
+
+        t1.start();
+        t2.start();
 
         while(!isSuspended(t2)) {
             sleep(100);
         }
+
+        testJvmtiThreadState(t2, SUSPENDED);
+
         resumeAllVirtualThreads();
 
         t2.join();
         t1.join();
+
+        testJvmtiThreadState(t1, TERMINATED);
+        testJvmtiThreadState(t2, TERMINATED);
     }
 
 }

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
@@ -57,7 +57,7 @@ public class SelfSuspendDisablerTest {
         }
     }
 
-    private static void testJvmtiThreadState(Thread thread, int expectedState) throws RuntimeException {
+    private static void testJvmtiThreadState(Thread thread, int expectedState) {
         String kindStr = thread.isVirtual()? "virtual " : "platform";
         int state = getThreadState(thread);
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/SelfSuspendDisablerTest.java
@@ -64,7 +64,7 @@ public class SelfSuspendDisablerTest {
         System.out.printf("Expected %s thread state: %06X got: %06X\n",
                           kindStr, expectedState, state);
         if (state != expectedState) {
-            throw new RuntimeException("Test FAILED: Unexpected thread state"); 
+            throw new RuntimeException("Test FAILED: Unexpected thread state");
         }
     }
 

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
@@ -65,7 +65,7 @@ Java_SelfSuspendDisablerTest_getThreadState(JNIEnv* jni, jclass cls, jthread thr
   return state;
 }
 
-}
+} // extern "C"
 
 
 JNIEXPORT jint JNICALL

--- a/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/vthread/SelfSuspendDisablerTest/libSelfSuspendDisablerTest.cpp
@@ -58,6 +58,13 @@ Java_SelfSuspendDisablerTest_resumeAllVirtualThreads(JNIEnv* jni, jclass cls) {
   check_jvmti_status(jni, jvmti->ResumeAllVirtualThreads(0, NULL), "Error in ResumeAllVirtualThreads");
 }
 
+JNIEXPORT jint JNICALL
+Java_SelfSuspendDisablerTest_getThreadState(JNIEnv* jni, jclass cls, jthread thread) {
+  jint state;
+  check_jvmti_status(jni, jvmti->GetThreadState(thread, &state), "Error in GetThreadState");
+  return state;
+}
+
 }
 
 


### PR DESCRIPTION
This is fixing the JVM TI GetThreadState issue which returns for terminated virtual thread state = 0 instead of 2 (`JVMTI_THREAD_STATE_TERMINATED`). The problem was in the function `JvmtiEnvBase::get_threadOop_and_JavaThread` which does a check and reurns JVMTI_ERROR_THREAD_NOT_ALIVE a little bit early (before the values of `java_thread` and `thread_oop` are set). This was a root cause of the `GetThreadState` incorrect behavior.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288703](https://bugs.openjdk.org/browse/JDK-8288703): GetThreadState returns 0 for virtual thread that has terminated


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**) ⚠️ Review applies to [85cb92ba](https://git.openjdk.org/jdk19/pull/102/files/85cb92ba674d0a0743fa1d70d100ef7459cc9ef5)
 * [Chris Plummer](https://openjdk.org/census#cjplummer) (@plummercj - **Reviewer**) ⚠️ Review applies to [7199e962](https://git.openjdk.org/jdk19/pull/102/files/7199e962800f4ccaaf5d5757ad824c8d214ce0bb)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/102/head:pull/102` \
`$ git checkout pull/102`

Update a local copy of the PR: \
`$ git checkout pull/102` \
`$ git pull https://git.openjdk.org/jdk19 pull/102/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 102`

View PR using the GUI difftool: \
`$ git pr show -t 102`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/102.diff">https://git.openjdk.org/jdk19/pull/102.diff</a>

</details>
