### PR TITLE
8245268: -Xcomp is missing from java launcher documentation

### DIFF
--- a/src/java.base/share/man/java.1
+++ b/src/java.base/share/man/java.1
@@ -873,6 +873,12 @@ Calling other JNI functions in the scope of
 Expect a performance degradation when this option is used.
 .RE
 .TP
+.B \f[CB]\-Xcomp\f[R]
+Testing mode to exercise JIT compilers.
+This option should not be used in production environments.
+.RS
+.RE
+.TP
 .B \f[CB]\-Xdebug\f[R]
 Does nothing.
 Provided for backward compatibility.


### PR DESCRIPTION
Updated man pages from markdown sources.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8245268](https://bugs.openjdk.org/browse/JDK-8245268): -Xcomp is missing from java launcher documentation


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/103/head:pull/103` \
`$ git checkout pull/103`

Update a local copy of the PR: \
`$ git checkout pull/103` \
`$ git pull https://git.openjdk.org/jdk19 pull/103/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 103`

View PR using the GUI difftool: \
`$ git pr show -t 103`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/103.diff">https://git.openjdk.org/jdk19/pull/103.diff</a>

</details>
