### PR TITLE
8287851: C2 crash: assert(t->meet(t0) == t) failed: Not monotonic

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -495,7 +495,6 @@ java/lang/invoke/LFCaching/LFMultiThreadCachingTest.java        8151492 generic-
 java/lang/invoke/LFCaching/LFGarbageCollectedTest.java          8078602 generic-all
 java/lang/invoke/lambda/LambdaFileEncodingSerialization.java    8249079 linux-x64
 java/lang/invoke/RicochetTest.java                              8251969 generic-all
-java/lang/CompressExpandTest.java                               8287851 generic-all
 java/lang/ref/OOMEInReferenceHandler.java                       8066859 generic-all
 
 ############################################################################


### PR DESCRIPTION
Hi All,

Patch fixes the assertion failure seen during conditional constant propagation optimization on account of
non-convergence, this happens when type values (lattice) associated with IR node seen during iterative data flow analysis are not-monotonic.

Problem was occurring due to incorrect result value range estimation by Value routines associated with Compress/ExpandBits IR nodes, non-constant mask lattice can take any value between _lo and _hi values,  special handling for +ve mask value range is using count_leading_zeros to estimate the maximum bit width needed to accommodate the result.  Since count_leading_zeros
accepts a long argument there by sign-extending integer argument, hence for integer case we need to subtract 32 from the results to get correct value.

Patch also fixes a typo resulting into a dead code reported by [JDK-8287855](https://bugs.openjdk.org/browse/JDK-8287855): Problem in compress_expand_identity.

Failing unit test java/lang/CompressExpandTest.java has been removed from ProblemList.txt.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287851](https://bugs.openjdk.org/browse/JDK-8287851): C2 crash:  assert(t->meet(t0) == t) failed: Not monotonic


### Reviewers
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Christian Hagedorn](https://openjdk.org/census#chagedorn) (@chhagedorn - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/104/head:pull/104` \
`$ git checkout pull/104`

Update a local copy of the PR: \
`$ git checkout pull/104` \
`$ git pull https://git.openjdk.org/jdk19 pull/104/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 104`

View PR using the GUI difftool: \
`$ git pr show -t 104`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/104.diff">https://git.openjdk.org/jdk19/pull/104.diff</a>

</details>
