### PR TITLE
8289601: MemorySegment.allocateUtf8String(String str) should be clarified for strings containing \0

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
+++ b/src/java.base/share/classes/java/lang/foreign/SegmentAllocator.java
@@ -76,6 +76,7 @@ public interface SegmentAllocator {
      * into a new memory segment obtained by calling {@code this.allocate(str.length() + 1)}.
      * @param str the Java string to be converted into a C string.
      * @return a new native memory segment containing the converted C string.
+     * @throws IllegalArgumentException if the UTF-8 encoded bytes of the given string contain a {@code 0} byte.
      */
     default MemorySegment allocateUtf8String(String str) {
         Objects.requireNonNull(str);

--- a/src/java.base/share/classes/jdk/internal/foreign/Utils.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/Utils.java
@@ -35,6 +35,7 @@ import java.lang.invoke.MethodHandle;
 import java.lang.invoke.MethodHandles;
 import java.lang.invoke.MethodType;
 import java.lang.invoke.VarHandle;
+import java.util.Arrays;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Supplier;
@@ -139,15 +140,15 @@ public final class Utils {
         return b ? (byte)1 : (byte)0;
     }
 
-    public static void copy(MemorySegment addr, byte[] bytes) {
-        var heapSegment = MemorySegment.ofArray(bytes);
-        addr.copyFrom(heapSegment);
-        addr.set(JAVA_BYTE, bytes.length, (byte)0);
-    }
-
     public static MemorySegment toCString(byte[] bytes, SegmentAllocator allocator) {
         MemorySegment addr = allocator.allocate(bytes.length + 1);
-        copy(addr, bytes);
+        for (int i = 0; i < bytes.length; i++) {
+            byte b = bytes[i];
+            if (b == 0) {
+                throw new IllegalArgumentException("String contains zero byte: " + Arrays.toString(bytes));
+            }
+            addr.set(JAVA_BYTE, i, b);
+        }
         return addr;
     }
 

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -204,6 +204,23 @@ public class TestSegmentAllocators {
         assertEquals(calls.get(), 1);
     }
 
+    @DataProvider
+    public Object[][] invalidStrings() {
+        return new Object[][] {
+                { "\0\0\0\0" },
+                { "ab\0d" }
+        };
+    }
+
+    @Test(dataProvider = "invalidStrings",
+            expectedExceptions = IllegalArgumentException.class,
+            expectedExceptionsMessageRegExp = ".*String contains zero byte.*")
+    public void testInvalidStrings(String invalid) {
+        try (MemorySession session = MemorySession.openConfined()) {
+            session.allocateUtf8String(invalid); // should fail
+        }
+    }
+
 
     @Test(dataProvider = "arrayAllocations")
     public <Z> void testArray(AllocationFactory allocationFactory, ValueLayout layout, AllocationFunction<Object, ValueLayout> allocationFunction, ToArrayHelper<Z> arrayHelper) {


### PR DESCRIPTION
This PR updates the spec and implementation to throw an `IllegalArgumentException` when an attempt is made to convert a Java string containing null characters to a C string.