### PR TITLE
8288592: JFR: Thread checkpoint no longer enforce mutual exclusion post Loom integration

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/jfrCheckpointManager.cpp
@@ -417,12 +417,11 @@ class ThreadLocalCheckpointWriteOp {
 };
 
 typedef CheckpointWriteOp<JfrCheckpointManager::Buffer> WriteOperation;
-typedef ThreadLocalCheckpointWriteOp<JfrCheckpointManager::Buffer> ThreadLocalWriteOperation;
-typedef MutexedWriteOp<WriteOperation> MutexedWriteOperation;
-typedef MutexedWriteOp<ThreadLocalWriteOperation> ThreadLocalMutexedWriteOperation;
+typedef ThreadLocalCheckpointWriteOp<JfrCheckpointManager::Buffer> ThreadLocalCheckpointOperation;
+typedef MutexedWriteOp<ThreadLocalCheckpointOperation> ThreadLocalWriteOperation;
 typedef ReleaseWithExcisionOp<JfrCheckpointMspace, JfrCheckpointMspace::LiveList> ReleaseOperation;
-typedef CompositeOperation<MutexedWriteOperation, ReleaseOperation> WriteReleaseOperation;
-typedef CompositeOperation<ThreadLocalMutexedWriteOperation, ReleaseOperation> ThreadLocalWriteReleaseOperation;
+typedef ExclusiveOp<WriteOperation> GlobalWriteOperation;
+typedef CompositeOperation<GlobalWriteOperation, ReleaseOperation> GlobalWriteReleaseOperation;
 
 void JfrCheckpointManager::begin_epoch_shift() {
   assert(SafepointSynchronize::is_at_safepoint(), "invariant");
@@ -439,31 +438,33 @@ void JfrCheckpointManager::end_epoch_shift() {
 size_t JfrCheckpointManager::write() {
   DEBUG_ONLY(JfrJavaSupport::check_java_thread_in_native(JavaThread::current()));
   WriteOperation wo(_chunkwriter);
-  MutexedWriteOperation mwo(wo);
+  GlobalWriteOperation gwo(wo);
   assert(_global_mspace->free_list_is_empty(), "invariant");
   ReleaseOperation ro(_global_mspace, _global_mspace->live_list(true));
-  WriteReleaseOperation wro(&mwo, &ro);
-  process_live_list(wro, _global_mspace, true); // previous epoch list
-  // Do thread local list after global. Careful, the tlwo destructor writes to chunk.
-  ThreadLocalWriteOperation tlwo(_chunkwriter);
-  ThreadLocalMutexedWriteOperation tlmwo(tlwo);
-  _thread_local_mspace->iterate(tlmwo, true); // previous epoch list
-  return wo.processed() + tlwo.processed();
+  GlobalWriteReleaseOperation gwro(&gwo, &ro);
+  process_live_list(gwro, _global_mspace, true); // previous epoch list
+  // Do thread local list after global. Careful, the tlco destructor writes to chunk.
+  ThreadLocalCheckpointOperation tlco(_chunkwriter);
+  ThreadLocalWriteOperation tlwo(tlco);
+  _thread_local_mspace->iterate(tlwo, true); // previous epoch list
+  return wo.processed() + tlco.processed();
 }
 
-typedef DiscardOp<DefaultDiscarder<JfrCheckpointManager::Buffer> > DiscardOperation;
-typedef CompositeOperation<DiscardOperation, ReleaseOperation> DiscardReleaseOperation;
+typedef DiscardOp<DefaultDiscarder<JfrCheckpointManager::Buffer> > ThreadLocalDiscardOperation;
+typedef ExclusiveDiscardOp<DefaultDiscarder<JfrCheckpointManager::Buffer> > GlobalDiscardOperation;
+typedef CompositeOperation<GlobalDiscardOperation, ReleaseOperation> DiscardReleaseOperation;
 
 size_t JfrCheckpointManager::clear() {
   JfrTraceIdLoadBarrier::clear();
   clear_type_set();
-  DiscardOperation discard_operation(mutexed); // mutexed discard mode
-  _thread_local_mspace->iterate(discard_operation, true); // previous epoch list
-  ReleaseOperation ro(_global_mspace, _global_mspace->live_list(true));
-  DiscardReleaseOperation discard_op(&discard_operation, &ro);
+  ThreadLocalDiscardOperation tldo(mutexed); // mutexed discard mode
+  _thread_local_mspace->iterate(tldo, true); // previous epoch list
+  GlobalDiscardOperation gdo(mutexed); // mutexed discard mode
+  ReleaseOperation ro(_global_mspace, _global_mspace->live_list(true)); // previous epoch list
+  DiscardReleaseOperation dro(&gdo, &ro);
   assert(_global_mspace->free_list_is_empty(), "invariant");
-  process_live_list(discard_op, _global_mspace, true); // previous epoch list
-  return discard_operation.elements();
+  process_live_list(dro, _global_mspace, true); // previous epoch list
+  return tldo.elements() + gdo.elements();
 }
 
 size_t JfrCheckpointManager::write_static_type_set(Thread* thread) {
@@ -560,14 +561,17 @@ size_t JfrCheckpointManager::flush_type_set() {
     }
   }
   if (_new_checkpoint.is_signaled_with_reset()) {
+    assert(_global_mspace->free_list_is_empty(), "invariant");
     assert(_global_mspace->live_list_is_nonempty(), "invariant");
     WriteOperation wo(_chunkwriter);
-    MutexedWriteOperation mwo(wo);
-    process_live_list(mwo, _global_mspace); // current epoch list
+    GlobalWriteOperation gwo(wo);
+    ReleaseOperation ro(_global_mspace, _global_mspace->live_list()); // current epoch list
+    GlobalWriteReleaseOperation gwro(&gwo, &ro);
+    process_live_list(gwro, _global_mspace); // current epoch list
     // Do thread local list after global. Careful, the tlwo destructor writes to chunk.
-    ThreadLocalWriteOperation tlwo(_chunkwriter);
-    ThreadLocalMutexedWriteOperation tlmwo(tlwo);
-    _thread_local_mspace->iterate(tlmwo); // current epoch list
+    ThreadLocalCheckpointOperation tlco(_chunkwriter);
+    ThreadLocalWriteOperation tlwo(tlco);
+    _thread_local_mspace->iterate(tlwo); // current epoch list
   }
   return elements;
 }

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.hpp
@@ -154,9 +154,11 @@ class PredicatedConcurrentWriteOp : public ConcurrentWriteOp<Operation> {
 
 template <typename Operation>
 class ExclusiveOp : private MutexedWriteOp<Operation> {
+ private:
+  Thread* const _thread;
  public:
   typedef typename Operation::Type Type;
-  ExclusiveOp(Operation& operation) : MutexedWriteOp<Operation>(operation) {}
+  ExclusiveOp(Operation& operation);
   bool process(Type* t);
   size_t processed() const { return MutexedWriteOp<Operation>::processed(); }
 };
@@ -181,9 +183,11 @@ class DiscardOp {
 
 template <typename Operation>
 class ExclusiveDiscardOp : private DiscardOp<Operation> {
+ private:
+  Thread* const _thread;
  public:
   typedef typename Operation::Type Type;
-  ExclusiveDiscardOp(jfr_operation_mode mode = concurrent) : DiscardOp<Operation>(mode) {}
+  ExclusiveDiscardOp(jfr_operation_mode mode = concurrent);
   bool process(Type* t);
   size_t processed() const { return DiscardOp<Operation>::processed(); }
   size_t elements() const { return DiscardOp<Operation>::elements(); }

--- a/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
+++ b/src/hotspot/share/jfr/recorder/storage/jfrStorageUtils.inline.hpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2016, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2016, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -91,12 +91,12 @@ inline bool MutexedWriteOp<Operation>::process(typename Operation::Type* t) {
 }
 
 template <typename Type>
-static void retired_sensitive_acquire(Type* t) {
+static void retired_sensitive_acquire(Type* t, Thread* thread) {
   assert(t != NULL, "invariant");
+  assert(thread != nullptr, "invariant");
   if (t->retired()) {
     return;
   }
-  Thread* const thread = Thread::current();
   while (!t->try_acquire(thread)) {
     if (t->retired()) {
       return;
@@ -105,10 +105,13 @@ static void retired_sensitive_acquire(Type* t) {
 }
 
 template <typename Operation>
+inline ExclusiveOp<Operation>::ExclusiveOp(Operation& operation) : MutexedWriteOp<Operation>(operation), _thread(Thread::current()) {}
+
+template <typename Operation>
 inline bool ExclusiveOp<Operation>::process(typename Operation::Type* t) {
-  retired_sensitive_acquire(t);
+  retired_sensitive_acquire(t, _thread);
   assert(t->acquired_by_self() || t->retired(), "invariant");
-  // User is required to ensure proper release of the acquisition
+  // The user is required to ensure proper release of the acquisition.
   return MutexedWriteOp<Operation>::process(t);
 }
 
@@ -134,10 +137,13 @@ inline bool DiscardOp<Operation>::process(typename Operation::Type* t) {
 }
 
 template <typename Operation>
+inline ExclusiveDiscardOp<Operation>::ExclusiveDiscardOp(jfr_operation_mode mode) : DiscardOp<Operation>(mode), _thread(Thread::current()) {}
+
+template <typename Operation>
 inline bool ExclusiveDiscardOp<Operation>::process(typename Operation::Type* t) {
-  retired_sensitive_acquire(t);
+  retired_sensitive_acquire(t, _thread);
   assert(t->acquired_by_self() || t->retired(), "invariant");
-  // User is required to ensure proper release of the acquisition
+  // The user is required to ensure proper release of the acquisition.
   return DiscardOp<Operation>::process(t);
 }
 


### PR DESCRIPTION
Greetings,

Before integrating Loom and Virtual Threads, threads writing checkpoint meta-information claimed a checkpoint buffer from a list categorized as thread-local.
Buffers on this list are not reset eagerly as part of a flushpoint but only as part of chunk rotation, where the JFR Recorder Thread has exclusive access by issuing a prior epoch shift.

With Loom, the thread-local buffers are exclusively dedicated to meta-information for Virtual Threads.
The meta-information about the JVM thread, for example, the carrier thread, is written to a buffer located on the list categorized as global. Buffers on this list are reset eagerly during flushpoints. Before Loom, an invariant for this global list was that only the JFR Recorder Thread used it.
This invariant no longer holds. The JFR Recorder Thread will reset buffers on this list without protection and can do so in the middle of another thread's attempted writes. Some consequences are asserts in debug builds and data loss in product builds.

Some mutex mechanism for the buffers on the global list must be re-introduced to prevent the JFR Recorder Thread from resetting buffers currently in use. This change set adds back proper protection.

Testing: jdk_jfr, stress

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [ ] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Integration blocker
&nbsp;⚠️ Title mismatch between PR and JBS for issue [JDK-8288592](https://bugs.openjdk.org/browse/JDK-8288592)

### Issue
 * [JDK-8288592](https://bugs.openjdk.org/browse/JDK-8288592): JVMTI GetClassSignature/getclsig005 failed "assert(_adapter.pos() == this->start_pos()) failed: invariant" ⚠️ Title mismatch between PR and JBS. ⚠️ Issue is not open.


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/108/head:pull/108` \
`$ git checkout pull/108`

Update a local copy of the PR: \
`$ git checkout pull/108` \
`$ git pull https://git.openjdk.org/jdk19 pull/108/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 108`

View PR using the GUI difftool: \
`$ git pr show -t 108`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/108.diff">https://git.openjdk.org/jdk19/pull/108.diff</a>

</details>
