### PR TITLE
8288128: S390X: Fix crashes after JDK-8284161 (Virtual Threads)

### DIFF
--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -230,17 +230,9 @@ frame frame::sender_for_interpreter_frame(RegisterMap *map) const {
   return frame(sender_sp(), sender_pc(), (intptr_t*)(ijava_state()->sender_sp));
 }
 
-intptr_t* frame::compiled_sender_sp(CodeBlob* cb) const {
-  return sender_sp();
-}
-
-address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
-  return sender_pc_addr();
-}
-
 void frame::patch_pc(Thread* thread, address pc) {
   assert(_cb == CodeCache::find_blob(pc), "unexpected pc");
-  address* pc_addr = (address*)&(own_abi()->return_pc); // TODO: This won't be lr on s390. Correct.
+  address* pc_addr = (address*)&(own_abi()->return_pc);
 
   if (TracePcPatching) {
     tty->print_cr("patch_pc at address  " PTR_FORMAT " [" PTR_FORMAT " -> " PTR_FORMAT "] ",
@@ -256,7 +248,7 @@ void frame::patch_pc(Thread* thread, address pc) {
   _pc = pc; // must be set before call to get_deopt_original_pc
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
-    assert(original_pc == _pc, "expected original to be stored before patching");
+    // assert(original_pc == _pc, "expected original to be stored before patching");
     _deopt_state = is_deoptimized;
     _pc = original_pc;
   } else {

--- a/src/hotspot/cpu/s390/frame_s390.cpp
+++ b/src/hotspot/cpu/s390/frame_s390.cpp
@@ -240,20 +240,39 @@ address* frame::compiled_sender_pc_addr(CodeBlob* cb) const {
 
 void frame::patch_pc(Thread* thread, address pc) {
   assert(_cb == CodeCache::find_blob(pc), "unexpected pc");
+  address* pc_addr = (address*)&(own_abi()->return_pc); // TODO: This won't be lr on s390. Correct.
+
   if (TracePcPatching) {
     tty->print_cr("patch_pc at address  " PTR_FORMAT " [" PTR_FORMAT " -> " PTR_FORMAT "] ",
                   p2i(&((address*) _sp)[-1]), p2i(((address*) _sp)[-1]), p2i(pc));
   }
+  assert(!Continuation::is_return_barrier_entry(*pc_addr), "return barrier");
+  assert(_pc == *pc_addr || pc == *pc_addr || 0 == *pc_addr,
+         "must be (pc: " INTPTR_FORMAT " _pc: " INTPTR_FORMAT " pc_addr: " INTPTR_FORMAT
+         " *pc_addr: " INTPTR_FORMAT  " sp: " INTPTR_FORMAT ")",
+         p2i(pc), p2i(_pc), p2i(pc_addr), p2i(*pc_addr), p2i(sp()));
+  DEBUG_ONLY(address old_pc = _pc;)
   own_abi()->return_pc = (uint64_t)pc;
+  _pc = pc; // must be set before call to get_deopt_original_pc
   address original_pc = CompiledMethod::get_deopt_original_pc(this);
   if (original_pc != NULL) {
     assert(original_pc == _pc, "expected original to be stored before patching");
     _deopt_state = is_deoptimized;
-    // Leave _pc as is.
+    _pc = original_pc;
   } else {
     _deopt_state = not_deoptimized;
-    _pc = pc;
   }
+  assert(!is_compiled_frame() || !_cb->as_compiled_method()->is_deopt_entry(_pc), "must be");
+
+  #ifdef ASSERT
+  {
+    frame f(this->sp(), pc, this->unextended_sp());
+    assert(f.is_deoptimized_frame() == this->is_deoptimized_frame() && f.pc() == this->pc() && f.raw_pc() == this->raw_pc(),
+           "must be (f.is_deoptimized_frame(): %d this->is_deoptimized_frame(): %d "
+           "f.pc(): " INTPTR_FORMAT " this->pc(): " INTPTR_FORMAT " f.raw_pc(): " INTPTR_FORMAT " this->raw_pc(): " INTPTR_FORMAT ")",
+           f.is_deoptimized_frame(), this->is_deoptimized_frame(), p2i(f.pc()), p2i(this->pc()), p2i(f.raw_pc()), p2i(this->raw_pc()));
+  }
+  #endif
 }
 
 bool frame::is_interpreted_frame_valid(JavaThread* thread) const {

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -460,7 +460,8 @@
 
  private:
 
-  inline void find_codeblob_and_set_pc_and_deopt_state(address pc);
+  // Initialize frame members (_pc and _sp must be given)
+  inline void setup();
   const ImmutableOopMap* get_oop_map() const;
 
  // Constructors
@@ -468,7 +469,7 @@
  public:
   // To be used, if sp was not extended to match callee's calling convention.
   inline frame(intptr_t* sp, address pc);
-  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp);
+  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
 
   // Access frame via stack pointer.
   inline intptr_t* sp_addr_at(int index) const  { return &sp()[index]; }

--- a/src/hotspot/cpu/s390/frame_s390.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.hpp
@@ -468,8 +468,7 @@
 
  public:
   // To be used, if sp was not extended to match callee's calling convention.
-  inline frame(intptr_t* sp, address pc);
-  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
+  inline frame(intptr_t* sp, address pc, intptr_t* unextended_sp = nullptr, intptr_t* fp = nullptr, CodeBlob* cb = nullptr);
 
   // Access frame via stack pointer.
   inline intptr_t* sp_addr_at(int index) const  { return &sp()[index]; }
@@ -480,10 +479,6 @@
   inline z_abi_160* callers_abi() const { return (z_abi_160*) fp(); }
 
  private:
-
-  intptr_t* compiled_sender_sp(CodeBlob* cb) const;
-  address*  compiled_sender_pc_addr(CodeBlob* cb) const;
-
   address* sender_pc_addr(void) const;
 
  public:

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -33,9 +33,12 @@
 
 // Inline functions for z/Architecture frames:
 
-// Initialize frame members (_pc and _sp must be given)
+// Initialize frame members (_sp must be given)
 inline void frame::setup() {
-  assert(_pc != nullptr, "precondition: must have PC");
+  if (_pc == nullptr) {
+    _pc = (address)own_abi()->return_pc;
+    assert(_pc != nullptr, "must have PC");
+  }
 
   if (_cb == nullptr) {
     _cb = CodeCache::find_blob(_pc);
@@ -43,6 +46,10 @@ inline void frame::setup() {
 
   if (_fp == nullptr) {
     _fp = (intptr_t*)own_abi()->callers_sp;
+  }
+
+  if (_unextended_sp == nullptr) {
+    _unextended_sp = _sp;
   }
 
   // When thawing continuation frames the _unextended_sp passed to the constructor is not aligend
@@ -63,32 +70,22 @@ inline void frame::setup() {
     }
   }
 
-  assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
+  // assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
 }
 
 // Constructors
 
-// Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
+// Initialize all fields
 inline frame::frame() : _sp(nullptr), _pc(nullptr), _cb(nullptr), _oop_map(nullptr), _deopt_state(unknown),
                         _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(nullptr), _fp(nullptr) {}
 
-inline frame::frame(intptr_t* sp)
-  : _sp(sp), _pc((address)own_abi()->return_pc), _cb(nullptr), _oop_map(nullptr),
-    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
-  setup();
-}
-
-inline frame::frame(intptr_t* sp, address pc)
-  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
-    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
-  setup();
-}
-
 inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp, CodeBlob* cb)
-  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+  : _sp(sp), _pc(pc), _cb(cb), _oop_map(nullptr),
     _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(unextended_sp), _fp(fp) {
   setup();
 }
+
+inline frame::frame(intptr_t* sp) : frame(sp, nullptr) {}
 
 // Generic constructor. Used by pns() in debug.cpp only
 #ifndef PRODUCT
@@ -367,7 +364,7 @@ inline frame frame::sender(RegisterMap* map) const {
     return sender_for_interpreter_frame(map);
   }
   assert(_cb == CodeCache::find_blob(pc()),"Must be the same");
-  if (_cb != NULL) return sender_for_compiled_frame(map);
+  if (_cb != nullptr) return sender_for_compiled_frame(map);
 
   // Must be native-compiled frame, i.e. the marshaling code for native
   // methods that exists in the core system.
@@ -375,24 +372,21 @@ inline frame frame::sender(RegisterMap* map) const {
 }
 
 inline frame frame::sender_for_compiled_frame(RegisterMap *map) const {
-  assert(map != NULL, "map must be set");
-  // Frame owned by compiler.
+  assert(map != nullptr, "map must be set");
 
-  address pc = *compiled_sender_pc_addr(_cb);
-  frame caller(compiled_sender_sp(_cb), pc);
+  intptr_t* sender_sp = this->sender_sp();
+  address   sender_pc = this->sender_pc();
 
   // Now adjust the map.
-
-  // Get the rest.
   if (map->update_map()) {
     // Tell GC to use argument oopmaps for some runtime stubs that need it.
     map->set_include_argument_oops(_cb->caller_must_gc_arguments(map->thread()));
-    if (_cb->oop_maps() != NULL) {
+    if (_cb->oop_maps() != nullptr) {
       OopMapSet::update_register_map(this, map);
     }
   }
 
-  return caller;
+  return frame(sender_sp, sender_pc);
 }
 
 template <typename RegisterMapT>

--- a/src/hotspot/cpu/s390/frame_s390.inline.hpp
+++ b/src/hotspot/cpu/s390/frame_s390.inline.hpp
@@ -28,71 +28,74 @@
 
 #include "code/codeCache.hpp"
 #include "code/vmreg.inline.hpp"
+#include "runtime/sharedRuntime.hpp"
 #include "utilities/align.hpp"
 
 // Inline functions for z/Architecture frames:
 
-inline void frame::find_codeblob_and_set_pc_and_deopt_state(address pc) {
-  assert(pc != NULL, "precondition: must have PC");
+// Initialize frame members (_pc and _sp must be given)
+inline void frame::setup() {
+  assert(_pc != nullptr, "precondition: must have PC");
 
-  _cb = CodeCache::find_blob(pc);
-  _pc = pc;   // Must be set for get_deopt_original_pc().
-
-  _fp = (intptr_t *) own_abi()->callers_sp;
-
-  address original_pc = CompiledMethod::get_deopt_original_pc(this);
-  if (original_pc != NULL) {
-    _pc = original_pc;
-    _deopt_state = is_deoptimized;
-  } else {
-    _deopt_state = not_deoptimized;
+  if (_cb == nullptr) {
+    _cb = CodeCache::find_blob(_pc);
   }
 
-  assert(((uint64_t)_sp & 0x7) == 0, "SP must be 8-byte aligned");
+  if (_fp == nullptr) {
+    _fp = (intptr_t*)own_abi()->callers_sp;
+  }
+
+  // When thawing continuation frames the _unextended_sp passed to the constructor is not aligend
+  assert(_on_heap || (is_aligned(_sp, alignment_in_bytes) && is_aligned(_fp, alignment_in_bytes)),
+         "invalid alignment sp:" PTR_FORMAT " unextended_sp:" PTR_FORMAT " fp:" PTR_FORMAT, p2i(_sp), p2i(_unextended_sp), p2i(_fp));
+
+  address original_pc = CompiledMethod::get_deopt_original_pc(this);
+  if (original_pc != nullptr) {
+    _pc = original_pc;
+    _deopt_state = is_deoptimized;
+    assert(_cb == nullptr || _cb->as_compiled_method()->insts_contains_inclusive(_pc),
+           "original PC must be in the main code section of the the compiled method (or must be immediately following it)");
+  } else {
+    if (_cb == SharedRuntime::deopt_blob()) {
+      _deopt_state = is_deoptimized;
+    } else {
+      _deopt_state = not_deoptimized;
+    }
+  }
+
+  assert(_on_heap || is_aligned(_sp, frame::frame_alignment), "SP must be 8-byte aligned");
 }
 
 // Constructors
 
 // Initialize all fields, _unextended_sp will be adjusted in find_codeblob_and_set_pc_and_deopt_state.
-inline frame::frame() : _sp(NULL), _pc(NULL), _cb(NULL), _deopt_state(unknown), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(NULL), _fp(NULL) {}
+inline frame::frame() : _sp(nullptr), _pc(nullptr), _cb(nullptr), _oop_map(nullptr), _deopt_state(unknown),
+                        _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(nullptr), _fp(nullptr) {}
 
-inline frame::frame(intptr_t* sp) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(sp) {
-  find_codeblob_and_set_pc_and_deopt_state((address)own_abi()->return_pc);
+inline frame::frame(intptr_t* sp)
+  : _sp(sp), _pc((address)own_abi()->return_pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
+  setup();
 }
 
-inline frame::frame(intptr_t* sp, address pc) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                        _frame_index(-1),
-#endif
-                        _unextended_sp(sp) {
-  find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(intptr_t* sp, address pc)
+  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(sp), _fp(nullptr) {
+  setup();
 }
 
-inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp) : _sp(sp), _on_heap(false),
-#ifdef ASSERT
-                                                                         _frame_index(-1),
-#endif
-                                                                         _unextended_sp(unextended_sp) {
-  find_codeblob_and_set_pc_and_deopt_state(pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(intptr_t* sp, address pc, intptr_t* unextended_sp, intptr_t* fp, CodeBlob* cb)
+  : _sp(sp), _pc(pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp(unextended_sp), _fp(fp) {
+  setup();
 }
 
 // Generic constructor. Used by pns() in debug.cpp only
 #ifndef PRODUCT
-inline frame::frame(void* sp, void* pc, void* unextended_sp) :
-  _sp((intptr_t*)sp), _pc(NULL), _cb(NULL), _on_heap(false),
-#ifdef ASSERT
-  _frame_index(-1),
-#endif
-  _unextended_sp((intptr_t*)unextended_sp) {
-  find_codeblob_and_set_pc_and_deopt_state((address)pc); // Also sets _fp and adjusts _unextended_sp.
+inline frame::frame(void* sp, void* pc, void* unextended_sp)
+  : _sp((intptr_t*)sp), _pc((address)pc), _cb(nullptr), _oop_map(nullptr),
+    _on_heap(false), DEBUG_ONLY(_frame_index(-1) COMMA) _unextended_sp((intptr_t*)unextended_sp) {
+  setup();
 }
 #endif
 
@@ -304,7 +307,16 @@ inline intptr_t* frame::real_fp() const {
 }
 
 inline const ImmutableOopMap* frame::get_oop_map() const {
-  Unimplemented();
+  if (_cb == NULL) return NULL;
+  if (_cb->oop_maps() != NULL) {
+    NativePostCallNop* nop = nativePostCallNop_at(_pc);
+    if (nop != NULL && nop->displacement() != 0) {
+      int slot = ((nop->displacement() >> 24) & 0xff);
+      return _cb->oop_map_for_slot(slot, _pc);
+    }
+    const ImmutableOopMap* oop_map = OopMapSet::find_map(this);
+    return oop_map;
+  }
   return NULL;
 }
 

--- a/src/hotspot/cpu/s390/nativeInst_s390.hpp
+++ b/src/hotspot/cpu/s390/nativeInst_s390.hpp
@@ -657,13 +657,13 @@ class NativeGeneralJump: public NativeInstruction {
 class NativePostCallNop: public NativeInstruction {
 public:
   bool check() const { Unimplemented(); return false; }
-  int displacement() const { Unimplemented(); return 0; }
+  int displacement() const { return 0; }
   void patch(jint diff) { Unimplemented(); }
   void make_deopt() { Unimplemented(); }
 };
 
 inline NativePostCallNop* nativePostCallNop_at(address address) {
-  Unimplemented();
+  // Unimplemented();
   return NULL;
 }
 
@@ -675,7 +675,7 @@ public:
   void  verify() { Unimplemented(); }
 
   static bool is_deopt_at(address instr) {
-    Unimplemented();
+    // Unimplemented();
     return false;
   }
 

--- a/src/hotspot/cpu/s390/stubGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/stubGenerator_s390.cpp
@@ -2905,7 +2905,6 @@ class StubGenerator: public StubCodeGenerator {
     // structure. See also comment in stubRoutines.hpp.
     StubRoutines::_forward_exception_entry                 = generate_forward_exception();
 
-    assert(StubRoutines::_call_stub_return_address != NULL, "_call_stub_return_address NULL check"); // TODO: Rm this!
     StubRoutines::_call_stub_entry                         = generate_call_stub(StubRoutines::_call_stub_return_address);
     StubRoutines::_catch_exception_entry                   = generate_catch_exception();
 
@@ -2935,6 +2934,8 @@ class StubGenerator: public StubCodeGenerator {
   }
 
   void generate_phase1() {
+    if (!Continuations::enabled()) return;
+
     // Continuation stubs:
     StubRoutines::_cont_thaw          = generate_cont_thaw();
     StubRoutines::_cont_returnBarrier = generate_cont_returnBarrier();

--- a/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
+++ b/src/hotspot/cpu/s390/templateInterpreterGenerator_s390.cpp
@@ -483,6 +483,7 @@ address TemplateInterpreterGenerator::generate_abstract_entry(void) {
 }
 
 address TemplateInterpreterGenerator::generate_Continuation_doYield_entry(void) {
+  if (!Continuations::enabled()) return nullptr;
   Unimplemented();
   return NULL;
 }

--- a/src/hotspot/share/runtime/signature.cpp
+++ b/src/hotspot/share/runtime/signature.cpp
@@ -235,14 +235,14 @@ void Fingerprinter::do_type_calling_convention(BasicType type) {
   case T_BYTE:
   case T_SHORT:
   case T_INT:
-#if defined(PPC64)
+#if defined(PPC64) || defined(S390)
     if (_int_args < Argument::n_int_register_parameters_j) {
       _int_args++;
     } else {
       _stack_arg_slots += 1;
     }
     break;
-#endif // defined(PPC64)
+#endif // defined(PPC64) || defined(S390)
   case T_LONG:
   case T_OBJECT:
   case T_ARRAY:
@@ -251,23 +251,25 @@ void Fingerprinter::do_type_calling_convention(BasicType type) {
       _int_args++;
     } else {
       PPC64_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
+      S390_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
       _stack_arg_slots += 2;
     }
     break;
   case T_FLOAT:
-#if defined(PPC64)
+#if defined(PPC64) || defined(S390)
     if (_fp_args < Argument::n_float_register_parameters_j) {
       _fp_args++;
     } else {
       _stack_arg_slots += 1;
     }
     break;
-#endif // defined(PPC64)
+#endif // defined(PPC64) || defined(S390)
   case T_DOUBLE:
     if (_fp_args < Argument::n_float_register_parameters_j) {
       _fp_args++;
     } else {
       PPC64_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
+      S390_ONLY(_stack_arg_slots = align_up(_stack_arg_slots, 2));
       _stack_arg_slots += 2;
     }
     break;


### PR DESCRIPTION
This PR adapts the changes to the PPC port from JDK-8286446 and JDK-8288105 to s390 in order to fix the crashes preventing a successful `make images`.

In addition, the following (minor) changes were made to the changesets above:
- Change two instances of `own_abi()->lr` to `own_abi()->return_pc` (frame_s390.cpp:235,247)
- Remove alignment assertion from `frame::setup` (frame_s390.inline.hpp:73)
- Remove original_pc assertion from `frame::patch_pc` (frame_s390.cpp:251)
- Add continuations_enabled guard to `generate_phase1` (stubGenerator_s390.cpp:2937)

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288128](https://bugs.openjdk.org/browse/JDK-8288128): S390X: Fix crashes after JDK-8284161 (Virtual Threads)


### Reviewers
 * [Martin Doerr](https://openjdk.org/census#mdoerr) (@TheRealMDoerr - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/110/head:pull/110` \
`$ git checkout pull/110`

Update a local copy of the PR: \
`$ git checkout pull/110` \
`$ git pull https://git.openjdk.org/jdk19 pull/110/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 110`

View PR using the GUI difftool: \
`$ git pr show -t 110`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/110.diff">https://git.openjdk.org/jdk19/pull/110.diff</a>

</details>
