### PR TITLE
8289779: Map::replaceAll javadoc has redundant @throws clauses

### DIFF
--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -739,21 +739,16 @@ public interface Map<K, V> {
      * @throws UnsupportedOperationException if the {@code set} operation
      * is not supported by this map's entry set iterator.
      * @throws ClassCastException if the class of a replacement value
-     * prevents it from being stored in this map
-     * @throws NullPointerException if the specified function is null, or the
-     * specified replacement value is null, and this map does not permit null
-     * values
-     * @throws ClassCastException if a replacement value is of an inappropriate
-     *         type for this map
+     *         prevents it from being stored in this map
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if function or a replacement value is null,
-     *         and this map does not permit null keys or values
+     * @throws NullPointerException if the specified function is null, or if a replacement value is null
+     *         and this map does not permit null values
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
      * @throws IllegalArgumentException if some property of a replacement value
      *         prevents it from being stored in this map
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
      * @throws ConcurrentModificationException if an entry is found to be
-     * removed during iteration
+     *         removed during iteration
      * @since 1.8
      */
     default void replaceAll(BiFunction<? super K, ? super V, ? extends V> function) {

--- a/src/java.base/share/classes/java/util/Map.java
+++ b/src/java.base/share/classes/java/util/Map.java
@@ -737,12 +737,12 @@ public interface Map<K, V> {
      *
      * @param function the function to apply to each entry
      * @throws UnsupportedOperationException if the {@code set} operation
-     * is not supported by this map's entry set iterator.
+     *         is not supported by this map's entry set iterator.
      * @throws ClassCastException if the class of a replacement value
      *         prevents it from being stored in this map
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
-     * @throws NullPointerException if the specified function is null, or if a replacement value is null
-     *         and this map does not permit null values
+     * @throws NullPointerException if the specified function is null, or if a
+     *         replacement value is null and this map does not permit null values
      *         (<a href="{@docRoot}/java.base/java/util/Collection.html#optional-restrictions">optional</a>)
      * @throws IllegalArgumentException if some property of a replacement value
      *         prevents it from being stored in this map


### PR DESCRIPTION
Simple javadoc fix of an editorial nature.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289779](https://bugs.openjdk.org/browse/JDK-8289779): Map::replaceAll javadoc has redundant @throws clauses


### Reviewers
 * [Pavel Rappo](https://openjdk.org/census#prappo) (@pavelrappo - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/111/head:pull/111` \
`$ git checkout pull/111`

Update a local copy of the PR: \
`$ git checkout pull/111` \
`$ git pull https://git.openjdk.org/jdk19 pull/111/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 111`

View PR using the GUI difftool: \
`$ git pr show -t 111`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/111.diff">https://git.openjdk.org/jdk19/pull/111.diff</a>

</details>
