### PR TITLE
8289477: Memory corruption with CPU_ALLOC, CPU_FREE on muslc

### DIFF
--- a/src/hotspot/os/linux/os_linux.cpp
+++ b/src/hotspot/os/linux/os_linux.cpp
@@ -4596,7 +4596,8 @@ static int _cpu_count(const cpu_set_t* cpus) {
 // dynamic check - see 6515172 for details.
 // If anything goes wrong we fallback to returning the number of online
 // processors - which can be greater than the number available to the process.
-int os::Linux::active_processor_count() {
+static int get_active_processor_count() {
+  // Note: keep this function, with its CPU_xx macros, *outside* the os namespace (see JDK-8289477).
   cpu_set_t cpus;  // can represent at most 1024 (CPU_SETSIZE) processors
   cpu_set_t* cpus_p = &cpus;
   int cpus_size = sizeof(cpu_set_t);
@@ -4666,6 +4667,10 @@ int os::Linux::active_processor_count() {
 
   assert(cpu_count > 0 && cpu_count <= os::processor_count(), "sanity check");
   return cpu_count;
+}
+
+int os::Linux::active_processor_count() {
+  return get_active_processor_count();
 }
 
 // Determine the active processor count from one of


### PR DESCRIPTION
Fixes a potential memory corruption (in 11 and 17, in 18 ++ it would "just" be an assert) if we run with more than 1024 CPUs on Alpine.

Fix is minimal and very safe.

This pull request contains a backport of commit [da6d1fc0](https://github.com/openjdk/jdk/commit/da6d1fc0e0aeb1fdb504aced4b0dba0290ec240f) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Thomas Stuefe on 30 Jun 2022 and was reviewed by David Holmes and Christoph Langer.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289477](https://bugs.openjdk.org/browse/JDK-8289477): Memory corruption with CPU_ALLOC, CPU_FREE on muslc


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/112/head:pull/112` \
`$ git checkout pull/112`

Update a local copy of the PR: \
`$ git checkout pull/112` \
`$ git pull https://git.openjdk.org/jdk19 pull/112/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 112`

View PR using the GUI difftool: \
`$ git pr show -t 112`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/112.diff">https://git.openjdk.org/jdk19/pull/112.diff</a>

</details>
