### PR TITLE
6509045

### DIFF
--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -25,7 +25,6 @@
 
 package jdk.javadoc.internal.doclets.toolkit.taglets;
 
-import java.util.ArrayList;
 import java.util.Collections;
 import java.util.EnumSet;
 import java.util.HashMap;
@@ -34,7 +33,6 @@ import java.util.Iterator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Map.Entry;
 import java.util.Set;
 
 import javax.lang.model.element.Element;
@@ -49,10 +47,8 @@ import com.sun.source.doctree.DocTree;
 import com.sun.source.doctree.ThrowsTree;
 
 import jdk.javadoc.doclet.Taglet.Location;
-import jdk.javadoc.internal.doclets.toolkit.BaseConfiguration;
 import jdk.javadoc.internal.doclets.toolkit.Content;
 import jdk.javadoc.internal.doclets.toolkit.util.DocFinder;
-import jdk.javadoc.internal.doclets.toolkit.util.Utils;
 
 /**
  * A taglet that processes {@link ThrowsTree}, which represents

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -196,8 +196,9 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
 
     private Map<ThrowsTree, Element> expand(ThrowsTree tag, Element e, Utils utils, BaseConfiguration configuration) {
         // basically, flatmap... @throws -> @throws*
-        final Map<ThrowsTree, Element> tags = new LinkedHashMap<>(); //
-        if (tag.getDescription().stream().anyMatch(d -> d.getKind() == DocTree.Kind.INHERIT_DOC)) {
+        if (tag.getDescription().stream().noneMatch(d -> d.getKind() == DocTree.Kind.INHERIT_DOC)) {
+            return Map.of(tag, e);
+        } else {
             // @throws is the only tag where it currently makes sense
             // to expand {@inheritDoc} to more than one tag.
             // So we override the normal flow of inheritance for this tag only.
@@ -212,18 +213,17 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             var output = DocFinder.search(configuration, input);
             if (output.tagList.size() <= 1) {
                 // old code will doo just fine
-                tags.put(tag, e);
+                return Map.of(tag, e);
             } else if (tag.getDescription().size() > 1) { // there's more inside @throws than just {@inheritDoc}
                 // error (cannot do this reliably, probably is a programmatic error)
                 // TODO: warn
-                tags.put(tag, e);
+                return Map.of(tag, e);
             } else {
+                Map<ThrowsTree, Element> tags = new LinkedHashMap<>(); //
                 output.tagList.forEach(t -> tags.put((ThrowsTree) t, output.holder));
+                return tags;
             }
-        } else {
-            tags.put(tag, e);
         }
-        return tags;
     }
 
     /**

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -206,11 +206,11 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
                                                       ExecutableElement e,
                                                       TagletWriter writer) {
 
-        // This method uses Map.of() for a single mapping.
-        // While the result of Map.of is effectively ordered,
-        // it makes for more compact code than that of LinkedHashMap.
+        // This method uses Map.of() to create maps of size zero and one.
+        // While such maps are effectively ordered, the syntax is more
+        // compact than that of LinkedHashMap.
 
-        // Peek into @throws description
+        // peek into @throws description
         if (tag.getDescription().stream().noneMatch(d -> d.getKind() == DocTree.Kind.INHERIT_DOC)) {
             // nothing to inherit
             return Map.of(tag, e);
@@ -218,15 +218,15 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         var input = new DocFinder.Input(writer.configuration().utils, e, this, new DocFinder.DocTreeInfo(tag, e), false, true);
         var output = DocFinder.search(writer.configuration(), input);
         if (output.tagList.size() <= 1) {
-            // outer code will handle that trivial case of inheritance
+            // outer code will handle this trivial case of inheritance
             return Map.of(tag, e);
         }
         if (tag.getDescription().size() > 1) {
             // there's more to description than just {@inheritDoc}
-            // it's likely a documentation error; drop anything
-            // but the inherited part and
-            // TODO warn the user
-            return Map.of(tag, e);
+            // it's likely a documentation error
+            var ch = writer.configuration().utils.getCommentHelper(e);
+            writer.configuration().getMessages().error(ch.getDocTreePath(tag), "doclet.inheritDocWithinInappropriateTag");
+            return Map.of();
         }
         Map<ThrowsTree, ExecutableElement> tags = new LinkedHashMap<>();
         output.tagList.forEach(t -> tags.put((ThrowsTree) t, (ExecutableElement) output.holder));

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -178,7 +178,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
             if (alreadyDocumented.isEmpty() && documentedInThisCall.isEmpty()) {
                 result.add(writer.getThrowsHeader());
             }
-            Map<ThrowsTree, Element> tags = expand(tag, e, utils, writer.configuration());
+            Map<ThrowsTree, Element> tags = expand(tag, e, writer);
             tags.forEach((t1, e1) -> {
                 result.add(writer.throwsTagOutput(e1, t1, substituteType));
                 if (substituteType != null) {
@@ -194,7 +194,7 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         return result;
     }
 
-    private Map<ThrowsTree, Element> expand(ThrowsTree tag, Element e, Utils utils, BaseConfiguration configuration) {
+    private Map<ThrowsTree, Element> expand(ThrowsTree tag, Element e, TagletWriter writer) {
         // although we could use LinkedHashMap for a single mapping too, to emphasize
         // that the order is important, a Map.of() would do just fine
         // basically, flatmap... @throws -> @throws*
@@ -210,8 +210,8 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
         //   2.1. if inherited none or one go skip, delegate to the old code
         //   2.2. otherwise (inherited more than one tag) raise an error
         // 3. otherwise (tag does not add to it), add all tags
-        var input = new DocFinder.Input(utils, e, this, new DocFinder.DocTreeInfo(tag, e), false, true);
-        var output = DocFinder.search(configuration, input);
+        var input = new DocFinder.Input(writer.configuration().utils, e, this, new DocFinder.DocTreeInfo(tag, e), false, true);
+        var output = DocFinder.search(writer.configuration(), input);
         if (output.tagList.size() <= 1) {
             // old code will doo just fine
             return Map.of(tag, e);

--- a/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
+++ b/src/jdk.javadoc/share/classes/jdk/javadoc/internal/doclets/toolkit/taglets/ThrowsTaglet.java
@@ -195,34 +195,34 @@ public class ThrowsTaglet extends BaseTaglet implements InheritableTaglet {
     }
 
     private Map<ThrowsTree, Element> expand(ThrowsTree tag, Element e, Utils utils, BaseConfiguration configuration) {
+        // although we could use LinkedHashMap for a single mapping too, to emphasize
+        // that the order is important, a Map.of() would do just fine
         // basically, flatmap... @throws -> @throws*
         if (tag.getDescription().stream().noneMatch(d -> d.getKind() == DocTree.Kind.INHERIT_DOC)) {
             return Map.of(tag, e);
+        }
+        // @throws is the only tag where it currently makes sense
+        // to expand {@inheritDoc} to more than one tag.
+        // So we override the normal flow of inheritance for this tag only.
+        // Here's what we do if @throws has {@inheritDoc} inside it:
+        // 1. try to inherit
+        // 2. if tag.getDescription() adds to it, then:
+        //   2.1. if inherited none or one go skip, delegate to the old code
+        //   2.2. otherwise (inherited more than one tag) raise an error
+        // 3. otherwise (tag does not add to it), add all tags
+        var input = new DocFinder.Input(utils, e, this, new DocFinder.DocTreeInfo(tag, e), false, true);
+        var output = DocFinder.search(configuration, input);
+        if (output.tagList.size() <= 1) {
+            // old code will doo just fine
+            return Map.of(tag, e);
+        } else if (tag.getDescription().size() > 1) { // there's more inside @throws than just {@inheritDoc}
+            // error (cannot do this reliably, probably is a programmatic error)
+            // TODO: warn
+            return Map.of(tag, e);
         } else {
-            // @throws is the only tag where it currently makes sense
-            // to expand {@inheritDoc} to more than one tag.
-            // So we override the normal flow of inheritance for this tag only.
-            // Here's what we do if @throws has {@inheritDoc} inside it:
-            // 1. try to inherit
-            // 2. if tag.getDescription() adds to it, then:
-            //   2.1. if inherited none or one go skip, delegate to the old code
-            //   2.2. otherwise (inherited more than one tag) raise an error
-            // 3. otherwise (tag does not add to it), add all tags
-            var input = new DocFinder.Input(utils, e, this,
-                    new DocFinder.DocTreeInfo(tag, e), false, true);
-            var output = DocFinder.search(configuration, input);
-            if (output.tagList.size() <= 1) {
-                // old code will doo just fine
-                return Map.of(tag, e);
-            } else if (tag.getDescription().size() > 1) { // there's more inside @throws than just {@inheritDoc}
-                // error (cannot do this reliably, probably is a programmatic error)
-                // TODO: warn
-                return Map.of(tag, e);
-            } else {
-                Map<ThrowsTree, Element> tags = new LinkedHashMap<>(); //
-                output.tagList.forEach(t -> tags.put((ThrowsTree) t, output.holder));
-                return tags;
-            }
+            Map<ThrowsTree, Element> tags = new LinkedHashMap<>(); //
+            output.tagList.forEach(t -> tags.put((ThrowsTree) t, output.holder));
+            return tags;
         }
     }
 

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8067757
+ * @bug 8067757 6509045
  * @library /tools/lib ../../lib
  * @modules jdk.compiler/com.sun.tools.javac.api
  *          jdk.compiler/com.sun.tools.javac.main
@@ -348,6 +348,99 @@ public class TestOneToMany extends JavadocTester {
                 <dt>Throws:</dt>
                 <dd><code><a href="MyException.html" title="class in x">MyException</a></code> - if this</dd>
                 <dd><code><a href="MySubException.html" title="class in x">MySubException</a></code> - if that</dd>
+                </dl>""");
+    }
+
+    @Test
+    public void testUncheckedExceptionTag(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyRuntimeException extends RuntimeException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    void m();
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    /**
+                     * @throws MyRuntimeException {@inheritDoc}
+                     */
+                    @Override
+                    void m();
+                }
+                """, """
+                package x;
+
+                public class IImpl implements I {
+
+                    /**
+                     * @throws MyRuntimeException {@inheritDoc}
+                     */
+                    @Override
+                    public void m() { }
+                }
+                """, """
+                package x;
+
+                public class C {
+
+                    /**
+                     * @throws MyRuntimeException if this
+                     * @throws MyRuntimeException if that
+                     */
+                    public void m();
+                }
+                """, """
+                package x;
+
+                public class C1 extends C {
+
+                    /**
+                     * @throws MyRuntimeException {@inheritDoc}
+                     */
+                    @Override
+                    public void m() { }
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/IImpl.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
+                </dl>""");
+        checkOutput("x/C1.html", true, """
+                <dl class="notes">
+                <dt>Overrides:</dt>
+                <dd><code><a href="C.html#m()">m</a></code>&nbsp;in class&nbsp;<code><a href="C.html" title="class in x">C</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if this</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
                 </dl>""");
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -469,7 +469,7 @@ public class TestOneToMany extends JavadocTester {
                     /**
                      * @throws MyRuntimeException sometimes
                      * @throws MyRuntimeException rarely
-                     * @throws MyRuntimeException {@inheritDoc}
+                     * @throws MyRuntimeException "{@inheritDoc}"
                      */
                     @Override
                     void m();
@@ -507,7 +507,7 @@ public class TestOneToMany extends JavadocTester {
                 <dt>Throws:</dt>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - sometimes</dd>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - rarely</dd>
-                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - always</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - "always"</dd>
                 </dl>""");
         checkOutput("x/I2.html", true, """
                 <dl class="notes">
@@ -519,8 +519,49 @@ public class TestOneToMany extends JavadocTester {
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - occasionally</dd>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - sometimes</dd>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - rarely</dd>
-                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - always</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - "always"</dd>
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - frequently</dd>
                 </dl>""");
+    }
+
+    @Test
+    public void testError(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyRuntimeException extends RuntimeException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyRuntimeException sometimes
+                     * @throws MyRuntimeException rarely
+                     */
+                    void m();
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    /**
+                     * @throws MyRuntimeException "{@inheritDoc}"
+                     */
+                    @Override
+                    void m();
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.ERROR);
+        checkOutput(Output.OUT, true, """
+                I1.java:6: error: @inheritDoc cannot be used within this tag
+                     * @throws MyRuntimeException "{@inheritDoc}"
+                       ^
+                       """);
     }
 }

--- a/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
+++ b/test/langtools/jdk/javadoc/doclet/testThrowsInheritanceMultiple/TestOneToMany.java
@@ -443,4 +443,84 @@ public class TestOneToMany extends JavadocTester {
                 <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - if that</dd>
                 </dl>""");
     }
+
+    @Test
+    public void testWholeShebang(Path base) throws Exception {
+        var src = base.resolve("src");
+        tb.writeJavaFiles(src, """
+                package x;
+
+                public class MyRuntimeException extends RuntimeException { }
+                """, """
+                package x;
+
+                public interface I {
+
+                    /**
+                     * @throws MyRuntimeException always
+                     */
+                    void m();
+                }
+                """, """
+                package x;
+
+                public interface I1 extends I {
+
+                    /**
+                     * @throws MyRuntimeException sometimes
+                     * @throws MyRuntimeException rarely
+                     * @throws MyRuntimeException {@inheritDoc}
+                     */
+                    @Override
+                    void m();
+                }
+                """, """
+                package x;
+
+                public interface I2 extends I1 {
+
+                    /**
+                     * @throws MyRuntimeException occasionally
+                     * @throws MyRuntimeException {@inheritDoc}
+                     * @throws MyRuntimeException frequently
+                     */
+                    @Override
+                    void m() throws MyRuntimeException,
+                                    MyRuntimeException,
+                                    MyRuntimeException,
+                                    MyRuntimeException;
+                }
+                """);
+        javadoc("-d", base.resolve("out").toString(),
+                "-sourcepath", src.toString(),
+                "x");
+        checkExit(Exit.OK);
+        checkOutput("x/I.html", true, """
+                <dl class="notes">
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - always</dd>
+                </dl>""");
+        checkOutput("x/I1.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - sometimes</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - rarely</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - always</dd>
+                </dl>""");
+        checkOutput("x/I2.html", true, """
+                <dl class="notes">
+                <dt>Specified by:</dt>
+                <dd><code><a href="I.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I.html" title="interface in x">I</a></code></dd>
+                <dt>Specified by:</dt>
+                <dd><code><a href="I1.html#m()">m</a></code>&nbsp;in interface&nbsp;<code><a href="I1.html" title="interface in x">I1</a></code></dd>
+                <dt>Throws:</dt>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - occasionally</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - sometimes</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - rarely</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - always</dd>
+                <dd><code><a href="MyRuntimeException.html" title="class in x">MyRuntimeException</a></code> - frequently</dd>
+                </dl>""");
+    }
 }


### PR DESCRIPTION
This is the second of the two PRs that fix inheritance for multiple `@throws` tags for a particular exception.

The first PR (8067757, #95) fixed inheritance for multiple `@throws` tags for an exception referred to by a `throws` clause. This PR fixes inheritance for multiple `@throws` tags for an exception referred to by an `@throws` tag.

It is expected that if an overriding method has an `@throws` tag that has an `{@inheritDoc}` in its description, then the documentation will inherit all tags that describe that same exception in the overridden methods. For example, support the setup looks like this:

* Overrider
   ```
   @throws NullPointerException if this
   @throws NullPointerException if that
   ```

* Overridee
   ```
   @throws NullPointerException {@inheritDoc}
   ```
Then the overridee's documentation should look like this:
```
Throws:
NullPointerException - if this
NullPointerException - if that 
```

While logical and expected, such behavior is different from other use cases of `{@inheritDoc}`. In other use cases `{@inheritDoc}` expands locally: it replaces itself with a list of tree nodes. Such a replacement doesn't affect any tree node other than its parent.

`{@inheritDoc}` expands locally everywhere, such as in the main description, `@param`, and `@return` tags, but it is not enough for `@throws`, which sometimes needs to amend the **grandparent** node to replace a `@throws` node with multiple `@throws` nodes. Amending this behavior globally just for `@throws` would be impractical.

For now, it seems reasonable to fix this by overriding the `{@inheritDoc}` processing just for `@throws`. This PR gives `ThrowsTaglet` an ability to peek at `@throws` description to see if there are any `{@inheritDoc}` there.

There's one limitation though. Suppose `@throws` documentation is both amended and inhertied from multiple `@throws` like this:

* Overridder
```
@throws NullPointerException if this
@throws NullPointerException if that
```

* Overridee
```
@throws NullPointerException "{@inheritDoc}"
```

It's not clear what to do in such a case. If only one of either amendment (a `"` quote before and after) or multiple-inheritance is present, it's clear what to do. But not when both are present. For now, such a situation is detected and flagged as an error (a test is provided).
