### PR TITLE
8289872: wrong wording in @param doc for HashMap.newHashMap et. al.

### DIFF
--- a/src/java.base/share/classes/java/util/HashMap.java
+++ b/src/java.base/share/classes/java/util/HashMap.java
@@ -2571,7 +2571,7 @@ public class HashMap<K,V> extends AbstractMap<K,V>
      * without resizing the map.
      *
      * @param numMappings the expected number of mappings
-     * @param <K>         the type of keys maintained by this map
+     * @param <K>         the type of keys maintained by the new map
      * @param <V>         the type of mapped values
      * @return the newly created map
      * @throws IllegalArgumentException if numMappings is negative

--- a/src/java.base/share/classes/java/util/LinkedHashMap.java
+++ b/src/java.base/share/classes/java/util/LinkedHashMap.java
@@ -803,7 +803,7 @@ public class LinkedHashMap<K,V>
      * without resizing the map.
      *
      * @param numMappings the expected number of mappings
-     * @param <K>         the type of keys maintained by this map
+     * @param <K>         the type of keys maintained by the new map
      * @param <V>         the type of mapped values
      * @return the newly created map
      * @throws IllegalArgumentException if numMappings is negative

--- a/src/java.base/share/classes/java/util/WeakHashMap.java
+++ b/src/java.base/share/classes/java/util/WeakHashMap.java
@@ -1350,7 +1350,7 @@ public class WeakHashMap<K,V>
      * without resizing the map.
      *
      * @param numMappings the expected number of mappings
-     * @param <K>         the type of keys maintained by this map
+     * @param <K>         the type of keys maintained by the new map
      * @param <V>         the type of mapped values
      * @return the newly created map
      * @throws IllegalArgumentException if numMappings is negative


### PR DESCRIPTION
Minor doc wording changes, to be consistent with HashSet.newHashSet et. al.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289872](https://bugs.openjdk.org/browse/JDK-8289872): wrong wording in @param doc for HashMap.newHashMap et. al.


### Reviewers
 * [Chris Hegarty](https://openjdk.org/census#chegar) (@ChrisHegarty - **Reviewer**)
 * [Naoto Sato](https://openjdk.org/census#naoto) (@naotoj - **Reviewer**)
 * [Iris Clark](https://openjdk.org/census#iris) (@irisclark - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/118/head:pull/118` \
`$ git checkout pull/118`

Update a local copy of the PR: \
`$ git checkout pull/118` \
`$ git pull https://git.openjdk.org/jdk19 pull/118/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 118`

View PR using the GUI difftool: \
`$ git pr show -t 118`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/118.diff">https://git.openjdk.org/jdk19/pull/118.diff</a>

</details>
