### PR TITLE
JDK-8289894: A NullPointerException thrown from guard expression

### DIFF
--- a/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
+++ b/src/jdk.compiler/share/classes/com/sun/tools/javac/comp/Check.java
@@ -4348,6 +4348,9 @@ public class Check {
                     wasDefault = true;
                 } else {
                     JCPattern pat = ((JCPatternCaseLabel) label).pat;
+                    while (pat instanceof JCParenthesizedPattern parenthesized) {
+                        pat = parenthesized.pattern;
+                    }
                     boolean isTypePattern = pat.hasTag(BINDINGPATTERN);
                     if (wasPattern || wasConstant || wasDefault ||
                         (wasNullPattern && (!isTypePattern || wasNonEmptyFallThrough))) {

--- a/test/langtools/tools/javac/patterns/CaseStructureTest.java
+++ b/test/langtools/tools/javac/patterns/CaseStructureTest.java
@@ -95,7 +95,7 @@ public class CaseStructureTest extends ComboInstance<CaseStructureTest> {
         task.generate(result -> {
             boolean shouldPass = true;
             long patternCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.TYPE_PATTERN || l == CaseLabel.PARENTHESIZED_PATTERN).count();
-            long typePatternCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.TYPE_PATTERN).count();
+            long typePatternCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.TYPE_PATTERN || l == CaseLabel.PARENTHESIZED_PATTERN).count();
             long constantCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.CONSTANT).count();
             long nullCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.NULL).count();
             long defaultCases = Arrays.stream(caseLabels).filter(l -> l == CaseLabel.DEFAULT).count();

--- a/test/langtools/tools/javac/patterns/Guards.java
+++ b/test/langtools/tools/javac/patterns/Guards.java
@@ -23,7 +23,7 @@
 
 /*
  * @test
- * @bug 8262891 8268663
+ * @bug 8262891 8268663 8289894
  * @summary Check guards implementation.
  * @compile --enable-preview -source ${jdk.version} Guards.java
  * @run main/othervm --enable-preview Guards
@@ -164,21 +164,29 @@ public class Guards {
     }
 
     void testGuardNPE() {
-        assertEquals("empty", guardNPE(""));
-        assertEquals("A", guardNPE("A"));
-        assertEquals("other", guardNPE(1));
-        try {
-            guardNPE(null);
-            throw new AssertionError("Expected exception missing.");
-        } catch (NullPointerException ex) {
-            //expected
-        }
+        doTestGuardNPE(this::guardNPE1);
+        doTestGuardNPE(this::guardNPE2);
     }
 
-    String guardNPE(Object o) {
+    void doTestGuardNPE(Function<Object, String> test) {
+        assertEquals("empty", test.apply(""));
+        assertEquals("A", test.apply("A"));
+        assertEquals("other", test.apply(1));
+        assertEquals("empty", test.apply(null));
+    }
+
+    String guardNPE1(Object o) {
         return switch (o) {
             case null, String s when s.isEmpty() -> "empty";
             case String s -> s;
+            case Object x -> "other";
+        };
+    }
+
+    String guardNPE2(Object o) {
+        return switch (o) {
+            case null, ((((String s)))) when s.isEmpty() -> "empty";
+            case ((((String s)))) -> s;
             case Object x -> "other";
         };
     }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.java
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.java
@@ -254,4 +254,32 @@ public class SwitchErrors {
             case int j: break;
         }
     }
+    void nullAndParenthesized1(Object o) {
+        record R(Object o) {}
+        switch (o) {
+            case null, ((R r)): break;
+            default: break;
+        }
+    }
+    void nullAndParenthesized2(Object o) {
+        record R(Object o) {}
+        switch (o) {
+            case null, ((R(var v))): break;
+            default: break;
+        }
+    }
+    void nullAndParenthesized3(Object o) {
+        record R(Object o) {}
+        switch (o) {
+            case ((R r)): case null: break;
+            default: break;
+        }
+    }
+    void nullAndParenthesized4(Object o) {
+        record R(Object o) {}
+        switch (o) {
+            case ((R(var v))): case null: break;
+            default: break;
+        }
+    }
 }

--- a/test/langtools/tools/javac/patterns/SwitchErrors.out
+++ b/test/langtools/tools/javac/patterns/SwitchErrors.out
@@ -41,6 +41,8 @@ SwitchErrors.java:232:47: compiler.err.flows.through.from.pattern
 SwitchErrors.java:244:18: compiler.err.duplicate.unconditional.pattern
 SwitchErrors.java:249:18: compiler.err.prob.found.req: (compiler.misc.not.applicable.types: int, java.lang.Integer)
 SwitchErrors.java:254:18: compiler.err.type.found.req: int, (compiler.misc.type.req.class.array)
+SwitchErrors.java:267:24: compiler.err.flows.through.to.pattern
+SwitchErrors.java:281:37: compiler.err.flows.through.from.pattern
 SwitchErrors.java:9:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:15:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:21:9: compiler.err.not.exhaustive.statement
@@ -55,4 +57,4 @@ SwitchErrors.java:164:9: compiler.err.not.exhaustive.statement
 SwitchErrors.java:237:9: compiler.err.not.exhaustive.statement
 - compiler.note.preview.filename: SwitchErrors.java, DEFAULT
 - compiler.note.preview.recompile
-55 errors
+57 errors


### PR DESCRIPTION
Consider the following code:
```
public class SwitchGuard {
    public static void main(String... args) {
        test(null);
    }
    private static void test(Object o) {
        switch (o) {
            case null, String s when s.isEmpty() -> System.err.println("OK.");
            default -> {}
        }
    }
}
```

In the current specification, the guard should not be invoked when `o` is `null`, but javac will invoke it, for historical reasons.

Also, as opposed to JDK 18/JEP 420, `case null, <pattern>` is allowed for parenthesized pattern when the parenthesized pattern encloses (directly or via other parenthesized patterns) a type pattern.

The patch proposed here strives to fix both of these problems.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289894](https://bugs.openjdk.org/browse/JDK-8289894): A NullPointerException thrown from guard expression


### Reviewers
 * [Vicente Romero](https://openjdk.org/census#vromero) (@vicente-romero-oracle - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/120/head:pull/120` \
`$ git checkout pull/120`

Update a local copy of the PR: \
`$ git checkout pull/120` \
`$ git pull https://git.openjdk.org/jdk19 pull/120/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 120`

View PR using the GUI difftool: \
`$ git pr show -t 120`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/120.diff">https://git.openjdk.org/jdk19/pull/120.diff</a>

</details>
