### PR TITLE
8289951: ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java on linux-x64 and macosx-x64

### DIFF
--- a/test/jdk/ProblemList.txt
+++ b/test/jdk/ProblemList.txt
@@ -759,6 +759,7 @@ jdk/jfr/startupargs/TestStartDuration.java                      8214685 windows-
 jdk/jfr/jvm/TestWaste.java                                      8282427 generic-all
 jdk/jfr/api/consumer/recordingstream/TestOnEvent.java           8255404 linux-x64
 jdk/jfr/event/runtime/TestActiveSettingEvent.java               8287832 generic-all
+jdk/jfr/api/consumer/TestRecordingFileWrite.java                8287699 linux-x64,macosx-x64
 
 ############################################################################
 


### PR DESCRIPTION
A trivial fix to ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java on linux-x64 and macosx-x64.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289951](https://bugs.openjdk.org/browse/JDK-8289951): ProblemList jdk/jfr/api/consumer/TestRecordingFileWrite.java on linux-x64 and macosx-x64


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/123/head:pull/123` \
`$ git checkout pull/123`

Update a local copy of the PR: \
`$ git checkout pull/123` \
`$ git pull https://git.openjdk.org/jdk19 pull/123/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 123`

View PR using the GUI difftool: \
`$ git pr show -t 123`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/123.diff">https://git.openjdk.org/jdk19/pull/123.diff</a>

</details>
