### PR TITLE
8290004: [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC

### DIFF
--- a/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
+++ b/src/hotspot/os_cpu/aix_ppc/thread_aix_ppc.cpp
@@ -32,14 +32,8 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = last_Java_sp();
+  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
   address pc = _anchor.last_Java_pc();
-
-  // Last_Java_pc is not set, if we come here from compiled code.
-  // Assume spill slot for link register contains a suitable pc.
-  // Should have been filled by method entry code.
-  if (pc == NULL)
-    pc =  (address) *(sp + 2);
 
   return frame(sp, pc);
 }

--- a/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
+++ b/src/hotspot/os_cpu/linux_ppc/thread_linux_ppc.cpp
@@ -31,15 +31,8 @@
 frame JavaThread::pd_last_frame() {
   assert(has_last_Java_frame(), "must have last_Java_sp() when suspended");
 
-  intptr_t* sp = last_Java_sp();
+  intptr_t* sp = Atomic::load_acquire(&_anchor._last_Java_sp);
   address pc = _anchor.last_Java_pc();
-
-  // Last_Java_pc is not set, if we come here from compiled code.
-  // Assume spill slot for link register contains a suitable pc.
-  // Should have been filled by method entry code.
-  if (pc == NULL) {
-    pc = (address) *(sp + 2);
-  }
 
   return frame(sp, pc);
 }


### PR DESCRIPTION
We must read last_Java_sp first memory ordering wise. Otherwise, last_Java_pc can be 0.
Note: Writer side already uses release semantics, see javaFrameAnchor_ppc.hpp.

Setting pc to `*(sp + 2)` is no longer needed. Frame constructor does that in `setup()`.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290004](https://bugs.openjdk.org/browse/JDK-8290004): [PPC64] JfrGetCallTrace: assert(_pc != nullptr) failed: must have PC


### Reviewers
 * [Richard Reingruber](https://openjdk.org/census#rrich) (@reinrich - **Reviewer**)
 * [Lutz Schmidt](https://openjdk.org/census#lucy) (@RealLucy - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/124/head:pull/124` \
`$ git checkout pull/124`

Update a local copy of the PR: \
`$ git checkout pull/124` \
`$ git pull https://git.openjdk.org/jdk19 pull/124/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 124`

View PR using the GUI difftool: \
`$ git pr show -t 124`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/124.diff">https://git.openjdk.org/jdk19/pull/124.diff</a>

</details>
