### PR TITLE
8289697: buffer overflow in MTLVertexCache.m: MTLVertexCache_AddGlyphQuad

### DIFF
--- a/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
+++ b/src/java.desktop/macosx/native/libawt_lwawt/java2d/metal/MTLVertexCache.m
@@ -65,6 +65,10 @@ static id<MTLRenderCommandEncoder> encoder = NULL;
         MTLVC_ADD_VERTEX(TX1, TY1, DX1, DY1, 0); \
     } while (0)
 
+// Next define should exactly match to the amount
+// of MTLVC_ADD_VERTEX in MTLVC_ADD_TRIANGLES
+#define VERTS_FOR_A_QUAD 6
+
 jboolean
 MTLVertexCache_InitVertexCache()
 {
@@ -219,7 +223,11 @@ MTLVertexCache_AddMaskQuad(MTLContext *mtlc,
     J2dTraceLn1(J2D_TRACE_INFO, "MTLVertexCache_AddMaskQuad: %d",
                 maskCacheIndex);
 
-    if (maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX)
+    // MTLVC_ADD_TRIANGLES at the end of this function
+    // will place VERTS_FOR_A_QUAD vertexes to the vertex cache
+    // check free space and flush if needed.
+    if ((maskCacheIndex >= MTLVC_MASK_CACHE_MAX_INDEX) ||
+         ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX))
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushVertexCache(mtlc);
@@ -305,7 +313,9 @@ MTLVertexCache_AddGlyphQuad(MTLContext *mtlc,
 {
     J2dTraceLn(J2D_TRACE_INFO, "MTLVertexCache_AddGlyphQuad");
 
-    if (vertexCacheIndex >= MTLVC_MAX_INDEX)
+    // MTLVC_ADD_TRIANGLES adds VERTS_FOR_A_QUAD vertexes into Cache
+    // so need to check space for VERTS_FOR_A_QUAD elements
+    if ((vertexCacheIndex + VERTS_FOR_A_QUAD) >= MTLVC_MAX_INDEX)
     {
         J2dTraceLn2(J2D_TRACE_INFO, "maskCacheIndex = %d, vertexCacheIndex = %d", maskCacheIndex, vertexCacheIndex);
         MTLVertexCache_FlushGlyphVertexCache();


### PR DESCRIPTION
Clean backport to jdk19

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289697](https://bugs.openjdk.org/browse/JDK-8289697): buffer overflow in MTLVertexCache.m: MTLVertexCache_AddGlyphQuad


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/125/head:pull/125` \
`$ git checkout pull/125`

Update a local copy of the PR: \
`$ git checkout pull/125` \
`$ git pull https://git.openjdk.org/jdk19 pull/125/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 125`

View PR using the GUI difftool: \
`$ git pr show -t 125`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/125.diff">https://git.openjdk.org/jdk19/pull/125.diff</a>

</details>
