### PR TITLE
8288112: C2: Error: ShouldNotReachHere() in Type::typerr()

### DIFF
--- a/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
+++ b/src/hotspot/cpu/x86/c2_MacroAssembler_x86.cpp
@@ -4886,6 +4886,7 @@ void C2_MacroAssembler::vector_reverse_byte64(BasicType bt, XMMRegister dst, XMM
       evprord(xtmp1, k0, src, 16, true, vec_enc);
       vector_swap_nbits(8, 0x00FF00FF, dst, xtmp1, xtmp2, rtmp, vec_enc);
       break;
+    case T_CHAR:
     case T_SHORT:
       // Swap upper and lower byte of each word.
       vector_swap_nbits(8, 0x00FF00FF, dst, src, xtmp2, rtmp, vec_enc);
@@ -4917,6 +4918,7 @@ void C2_MacroAssembler::vector_reverse_byte(BasicType bt, XMMRegister dst, XMMRe
     case T_INT:
       vmovdqu(dst, ExternalAddress(StubRoutines::x86::vector_reverse_byte_perm_mask_int()), rtmp, vec_enc);
       break;
+    case T_CHAR:
     case T_SHORT:
       vmovdqu(dst, ExternalAddress(StubRoutines::x86::vector_reverse_byte_perm_mask_short()), rtmp, vec_enc);
       break;

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2693,7 +2693,7 @@ bool SuperWord::output() {
         vlen_in_bytes = vn->as_Vector()->length_in_bytes();
       } else {
         if (do_reserve_copy()) {
-          NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: ShouldNotReachHere, exiting SuperWord");})
+          NOT_PRODUCT(if(is_trace_loop_reverse() || TraceLoopOpts) {tty->print_cr("SWPointer::output: Unhandled scalar opcode (%s), ShouldNotReachHere, exiting SuperWord", NodeClassNames[opc]);})
           return false; //and reverse to backup IG
         }
         ShouldNotReachHere();

--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -2610,6 +2610,8 @@ bool SuperWord::output() {
                  opc == Op_NegF || opc == Op_NegD ||
                  opc == Op_RoundF || opc == Op_RoundD ||
                  opc == Op_PopCountI || opc == Op_PopCountL ||
+                 opc == Op_ReverseBytesI || opc == Op_ReverseBytesL ||
+                 opc == Op_ReverseBytesUS || opc == Op_ReverseBytesS ||
                  opc == Op_CountLeadingZerosI || opc == Op_CountLeadingZerosL ||
                  opc == Op_CountTrailingZerosI || opc == Op_CountTrailingZerosL) {
         assert(n->req() == 2, "only one input expected");

--- a/src/hotspot/share/opto/vectornode.cpp
+++ b/src/hotspot/share/opto/vectornode.cpp
@@ -171,6 +171,7 @@ int VectorNode::opcode(int sopc, BasicType bt) {
   case Op_ReverseBytesS:
   case Op_ReverseBytesI:
   case Op_ReverseBytesL:
+  case Op_ReverseBytesUS:
     return (is_integral_type(bt) ? Op_ReverseBytesV : 0);
   case Op_CompressBits:
     // Not implemented. Returning 0 temporarily

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestIntVect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2020, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -456,6 +456,10 @@ public class TestIntVect {
       test_srav_and(a0, a1, BIT_MASK);
       for (int i=0; i<ARRLEN; i++) {
         errn += verify("test_srav_and: ", i, a0[i], (int)(((int)(ADD_INIT+i) & BIT_MASK)>>VALUE));
+      }
+      test_reverse_bytes(a0, a1);
+      for (int i=0; i<ARRLEN; i++) {
+        errn += verify("test_reverse_bytes: ", i, a0[i], Integer.reverseBytes(a1[i]));
       }
 
       test_pack2(p2, a1);
@@ -922,7 +926,13 @@ public class TestIntVect {
       test_srav_and(a0, a1, BIT_MASK);
     }
     end = System.currentTimeMillis();
-    System.out.println("test_srav_and: " + (end - start));
+
+    start = System.currentTimeMillis();
+    for (int i=0; i<ITERS; i++) {
+      test_reverse_bytes(a0, a1);
+    }
+    end = System.currentTimeMillis();
+    System.out.println("test_reverse_bytes: " + (end - start));
 
     start = System.currentTimeMillis();
     for (int i=0; i<ITERS; i++) {
@@ -1268,6 +1278,12 @@ public class TestIntVect {
       long l = p2[i];
       a0[i*2+0] = (int)(l >> 32);
       a0[i*2+1] = (int)(l & 0xFFFFFFFFl);
+    }
+  }
+
+  static void test_reverse_bytes(int [] a0, int [] a1) {
+    for(int i = 0; i < a0.length; i++) {
+      a0[i] = Integer.reverseBytes(a1[i]);
     }
   }
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -432,7 +432,10 @@ public class TestLongVect {
       for (int i=0; i<ARRLEN; i++) {
         errn += verify("test_srav_and: ", i, a0[i], (long)(((long)(ADD_INIT+i) & BIT_MASK)>>VALUE));
       }
-
+      test_reverse_bytes(a0, a1);
+      for (int i=0; i<ARRLEN; i++) {
+        errn += verify("test_reverse_bytes: ", i, a0[i], Long.reverseBytes(a1[i]));
+      }
     }
 
     if (errn > 0)
@@ -853,6 +856,13 @@ public class TestLongVect {
     end = System.currentTimeMillis();
     System.out.println("test_srav_and: " + (end - start));
 
+    start = System.currentTimeMillis();
+    for (int i=0; i<ITERS; i++) {
+      test_reverse_bytes(a0, a1);
+    }
+    end = System.currentTimeMillis();
+    System.out.println("test_reverse_bytes: " + (end - start));
+
     return errn;
   }
 
@@ -1121,6 +1131,11 @@ public class TestLongVect {
   static void test_srav_and(long[] a0, long[] a1, long b) {
     for (int i = 0; i < a0.length; i+=1) {
       a0[i] = (long)((a1[i] & b)>>VALUE);
+    }
+  }
+  static void test_reverse_bytes(long[] a0, long[] a1) {
+    for(int i = 0; i < a0.length; i++) {
+      a0[i] = Long.reverseBytes(a1[i]);
     }
   }
 

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestLongVect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it

--- a/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
+++ b/test/hotspot/jtreg/compiler/c2/cr6340864/TestShortVect.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2012, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2012, 2022 Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -441,6 +441,10 @@ public class TestShortVect {
       test_srav_and(a0, a1, BIT_MASK);
       for (int i=0; i<ARRLEN; i++) {
         errn += verify("test_srav_and: ", i, a0[i], (short)(((short)(ADD_INIT+i) & BIT_MASK)>>VALUE));
+      }
+      test_reverse_bytes(a0, a1);
+      for (int i=0; i<ARRLEN; i++) {
+        errn += verify("test_reverse_bytes: ", i, a0[i], Short.reverseBytes(a1[i]));
       }
 
       test_pack2(p2, a1);
@@ -915,7 +919,13 @@ public class TestShortVect {
       test_srav_and(a0, a1, BIT_MASK);
     }
     end = System.currentTimeMillis();
-    System.out.println("test_srav_and: " + (end - start));
+
+    start = System.currentTimeMillis();
+    for (int i=0; i<ITERS; i++) {
+      test_reverse_bytes(a0, a1);
+    }
+    end = System.currentTimeMillis();
+    System.out.println("test_reverse_bytes: " + (end - start));
 
     start = System.currentTimeMillis();
     for (int i=0; i<ITERS; i++) {
@@ -1237,7 +1247,11 @@ public class TestShortVect {
       a0[i] = (short)((a1[i] & b)>>VALUE);
     }
   }
-
+  static void test_reverse_bytes(short[] a0, short[] a1) {
+    for(int i = 0; i < a0.length; i+=1) {
+      a0[i] = Short.reverseBytes(a1[i]);
+    }
+  }
   static void test_pack2(int[] p2, short[] a1) {
     if (p2.length*2 > a1.length) return;
     for (int i = 0; i < p2.length; i+=1) {

--- a/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
+++ b/test/hotspot/jtreg/compiler/vectorization/TestReverseBytes.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+/**
+ * @test
+ * @bug 8288112
+ * @summary Auto-vectorization of ReverseBytes operations.
+ * @requires vm.compiler2.enabled
+ * @requires vm.cpu.features ~= ".*avx2.*"
+ * @requires os.simpleArch == "x64"
+ * @library /test/lib /
+ * @run driver compiler.vectorization.TestReverseBytes
+ */
+
+package compiler.vectorization;
+
+import compiler.lib.ir_framework.*;
+import java.util.Random;
+
+public class TestReverseBytes {
+  private static final int ARRLEN = 1024;
+  private static final int ITERS  = 11000;
+
+  private static long [] linp;
+  private static long [] lout;
+  private static int  [] iinp;
+  private static int  [] iout;
+  private static short [] sinp;
+  private static short [] sout;
+  private static char [] cinp;
+  private static char [] cout;
+
+  public static void setup() {
+      Random r = new Random(1024);
+      linp = new long[ARRLEN];
+      lout = new long[ARRLEN];
+      iinp = new int[ARRLEN];
+      iout = new int[ARRLEN];
+      sinp = new short[ARRLEN];
+      sout = new short[ARRLEN];
+      cinp = new char[ARRLEN];
+      cout = new char[ARRLEN];
+      for(int i = 0; i < ARRLEN; i++) {
+          linp[i] = r.nextLong();
+          iinp[i] = r.nextInt();
+          sinp[i] = (short)r.nextInt();
+          cinp[i] = (char)r.nextInt();
+      }
+  }
+
+  public static void main(String args[]) {
+      setup();
+      TestFramework.runWithFlags("-XX:-TieredCompilation",
+                                  "-XX:CompileThresholdScaling=0.3");
+      System.out.println("PASSED");
+  }
+
+  @Test
+  @IR(counts = {"ReverseBytesV" , " > 0 "})
+  public void test_reverse_bytes_long(long[] lout, long[] linp) {
+      for (int i = 0; i < lout.length; i+=1) {
+          lout[i] = Long.reverseBytes(linp[i]);
+      }
+  }
+
+  @Run(test = {"test_reverse_bytes_long"}, mode = RunMode.STANDALONE)
+  public void kernel_test_reverse_bytes_long() {
+      setup();
+      for (int i = 0; i < ITERS; i++) {
+          test_reverse_bytes_long(lout , linp);
+      }
+  }
+
+  @Test
+  @IR(counts = {"ReverseBytesV" , " > 0 "})
+  public void test_reverse_bytes_int(int[] iout, int[] iinp) {
+      for (int i = 0; i < iout.length; i+=1) {
+          iout[i] = Integer.reverseBytes(iinp[i]);
+      }
+  }
+
+  @Run(test = {"test_reverse_bytes_int"}, mode = RunMode.STANDALONE)
+  public void kernel_test_reverse_bytes_int() {
+      setup();
+      for (int i = 0; i < ITERS; i++) {
+          test_reverse_bytes_int(iout , iinp);
+      }
+  }
+
+  @Test
+  @IR(counts = {"ReverseBytesV" , " > 0 "})
+  public void test_reverse_bytes_short(short[] sout, short[] sinp) {
+      for (int i = 0; i < sout.length; i+=1) {
+          sout[i] = Short.reverseBytes(sinp[i]);
+      }
+  }
+
+  @Run(test = {"test_reverse_bytes_short"}, mode = RunMode.STANDALONE)
+  public void kernel_test_reverse_bytes_short() {
+      setup();
+      for (int i = 0; i < ITERS; i++) {
+          test_reverse_bytes_short(sout , sinp);
+      }
+  }
+
+  @Test
+  @IR(counts = {"ReverseBytesV" , " > 0 "})
+  public void test_reverse_bytes_char(char[] cout, char[] cinp) {
+      for (int i = 0; i < cout.length; i+=1) {
+          cout[i] = Character.reverseBytes(cinp[i]);
+      }
+  }
+
+  @Run(test = {"test_reverse_bytes_char"}, mode = RunMode.STANDALONE)
+  public void kernel_test_reverse_bytes_char() {
+      setup();
+      for (int i = 0; i < ITERS; i++) {
+          test_reverse_bytes_char(cout , cinp);
+      }
+  }
+}

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -56,6 +56,7 @@ public class Integers {
     private int[] intsTiny;
     private int[] intsSmall;
     private int[] intsBig;
+    private int[] res;
 
     @Setup
     public void setup() {
@@ -64,6 +65,7 @@ public class Integers {
         intsTiny  = new int[size];
         intsSmall = new int[size];
         intsBig   = new int[size];
+        res       = new int[size];
         for (int i = 0; i < size; i++) {
             strings[i] = "" + (r.nextInt(10000) - (5000));
             intsTiny[i] = r.nextInt(99);
@@ -148,10 +150,10 @@ public class Integers {
     }
 
     @Benchmark
-    public void reverseBytes(Blackhole bh) {
+    public int [] reverseBytes() {
         for (int i = 0; i < size; i++) {
-            int r = Integer.reverseBytes(intsSmall[i]);
-            bh.consume(r);
+            res[i] = Integer.reverseBytes(intsSmall[i]);
         }
+        return res;
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -146,4 +146,12 @@ public class Integers {
             bh.consume(intsBig[i] << intsSmall[i]);
         }
     }
+
+    @Benchmark
+    public void reverseBytes(Blackhole bh) {
+        for (int i = 0; i < size; i++) {
+            int r = Integer.reverseBytes(intsSmall[i]);
+            bh.consume(r);
+        }
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Integers.java
+++ b/test/micro/org/openjdk/bench/java/lang/Integers.java
@@ -150,10 +150,9 @@ public class Integers {
     }
 
     @Benchmark
-    public int [] reverseBytes() {
+    public void reverseBytes() {
         for (int i = 0; i < size; i++) {
             res[i] = Integer.reverseBytes(intsSmall[i]);
         }
-        return res;
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -141,4 +141,12 @@ public class Longs {
             bh.consume(longArrayBig[i] << longArraySmall[i]);
         }
     }
+
+    @Benchmark
+    public void reverseBytes(Blackhole bh) {
+        for (int i = 0; i < size; i++) {
+            int r = Long.reverseBytes(longArraySmall[i]);
+            bh.consume(r);
+        }
+    }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -145,10 +145,9 @@ public class Longs {
     }
 
     @Benchmark
-    public long [] reverseBytes() {
+    public void reverseBytes() {
         for (int i = 0; i < size; i++) {
             res[i] = Long.reverseBytes(longArraySmall[i]);
         }
-        return res;
     }
 }

--- a/test/micro/org/openjdk/bench/java/lang/Longs.java
+++ b/test/micro/org/openjdk/bench/java/lang/Longs.java
@@ -49,6 +49,7 @@ public class Longs {
     @Param("500")
     private int size;
 
+    private long[] res;
     private String[] strings;
     private long[] longArraySmall;
     private long[] longArrayBig;
@@ -57,6 +58,7 @@ public class Longs {
     public void setup() {
         var random = ThreadLocalRandom.current();
         strings = new String[size];
+        res = new long[size];
         longArraySmall = new long[size];
         longArrayBig = new long[size];
         for (int i = 0; i < size; i++) {
@@ -143,10 +145,10 @@ public class Longs {
     }
 
     @Benchmark
-    public void reverseBytes(Blackhole bh) {
+    public long [] reverseBytes() {
         for (int i = 0; i < size; i++) {
-            int r = Long.reverseBytes(longArraySmall[i]);
-            bh.consume(r);
+            res[i] = Long.reverseBytes(longArraySmall[i]);
         }
+        return res;
     }
 }


### PR DESCRIPTION
[JDK-8284960](https://bugs.openjdk.org/browse/JDK-8284960) added new vector IR nodes and target specific backend support for  ReverseByte vector operations.  
For each scalar operation, auto-vectorizer analysis stage checks for existence of vector IR opcode and target specific backend implementation.  While processing scalar IR nodes corresponding to Java SE APIs [Short/Character/Integer/Long].reverseBytes SLP analysis checks passes since relevant support already existed. This bug fix patch handles missing scalar reversebyte opcode checks in SLP backed to enable creation of corresponding vector IR nodes.

A new JBS issue [JDK-8290034](https://bugs.openjdk.org/browse/JDK-8290034) is created to add the missing auto-vectorization support for bit reverse operation targeting JDK mainline.

Kindly review and share your feedback.

Best Regards,
Jatin

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288112](https://bugs.openjdk.org/browse/JDK-8288112): C2: Error: ShouldNotReachHere() in Type::typerr()


### Reviewers
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/128/head:pull/128` \
`$ git checkout pull/128`

Update a local copy of the PR: \
`$ git checkout pull/128` \
`$ git pull https://git.openjdk.org/jdk19 pull/128/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 128`

View PR using the GUI difftool: \
`$ git pr show -t 128`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/128.diff">https://git.openjdk.org/jdk19/pull/128.diff</a>

</details>
