### PR TITLE
8289709: fatal error: stuck in JvmtiVTMSTransitionDisabler::disable_VTMS_transitions

### DIFF
--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
@@ -48,7 +48,7 @@
  * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} framepop02.java
- * @run main/othervm/native --enable-preview -agentlib:framepop02 framepop02 virtual
+ * @run main/othervm/native/timeout=360 --enable-preview -agentlib:framepop02 framepop02 virtual
  */
 
 public class framepop02 {

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/framepop02.java
@@ -48,12 +48,12 @@
  * @requires vm.continuations
  * @library /test/lib
  * @compile --enable-preview -source ${jdk.version} framepop02.java
- * @run main/othervm/native/timeout=360 --enable-preview -agentlib:framepop02 framepop02 virtual
+ * @run main/othervm/native --enable-preview -agentlib:framepop02 framepop02 virtual
  */
 
 public class framepop02 {
 
-    final static int MAX_THREADS_LIMIT = 32;
+    final static int MAX_THREADS_LIMIT = 20;
     final static int NESTING_DEPTH = 20;
     final static String TEST_THREAD_NAME_BASE = "Test Thread #";
 

--- a/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
+++ b/test/hotspot/jtreg/serviceability/jvmti/events/FramePop/framepop02/libframepop02.cpp
@@ -228,7 +228,7 @@ void JNICALL FramePop(jvmtiEnv *jvmti, JNIEnv *jni,
   }
   check_jvmti_status(jni, jvmti->GetFrameCount(thr, &frameCount), "Error in GetFrameCount.");
 
-  { 
+  {
     if (printdump == JNI_TRUE) {
       print_current_time();
       fflush(0);


### PR DESCRIPTION
This is a test bug. The test should filter out non-tested threads to avoid generating such kind of deadlocks. 

In short, the deadlock dependencies are:

- The `Common-Cleaner` thread is executing the JVM TI agent `MethodEntry` event callback which grabbed the `agent_lock` raw monitor and calls JVM TI `GetFrameCount`. The `GetFrameCount` is blocked in disabling VTMS transitions because the `ForkJoinPool-1-worker-2` is at a mount (VTMS) transition.
- The `ForkJoinPool-1-worker-2` is at mount (VTMS) transition and blocked in `java.lang.ref.NativeReferenceQueue.poll()` when acquiring the `NativeReferenceQueue` lock which is held by the `Reference Handler` thread.
- The `Reference Handler` thread grabbed the `NativeReferenceQueue` lock and is entering the `signal()` method. It triggered a JVM TI `MethodEntry` event. The JVM TI agent `MethodEntry` event callback is blocked on grabbing the `agent_lock` raw monitor which is held by the `Common-Cleaner` thread.

Also, the `timeout=360 `is explicitly set to avoid frequent timeouts in locals runs. 

Testing: submitted mach5 job with 100 runs on 3 debug platforms.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289709](https://bugs.openjdk.org/browse/JDK-8289709): fatal error: stuck in JvmtiVTMSTransitionDisabler::disable_VTMS_transitions


### Reviewers
 * [Alan Bateman](https://openjdk.org/census#alanb) (@AlanBateman - **Reviewer**)
 * [Alex Menkov](https://openjdk.org/census#amenkov) (@alexmenkov - **Reviewer**)
 * [Leonid Mesnik](https://openjdk.org/census#lmesnik) (@lmesnik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/129/head:pull/129` \
`$ git checkout pull/129`

Update a local copy of the PR: \
`$ git checkout pull/129` \
`$ git pull https://git.openjdk.org/jdk19 pull/129/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 129`

View PR using the GUI difftool: \
`$ git pr show -t 129`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/129.diff">https://git.openjdk.org/jdk19/pull/129.diff</a>

</details>
