### PR TITLE
8289954: C2: Assert failed in PhaseCFG::verify() after JDK-8183390

### DIFF
--- a/src/hotspot/share/opto/superword.cpp
+++ b/src/hotspot/share/opto/superword.cpp
@@ -414,7 +414,9 @@ void SuperWord::unrolling_analysis(int &local_loop_unroll_factor) {
       cl->mark_passed_slp();
     }
     cl->mark_was_slp();
-    cl->set_slp_max_unroll(local_loop_unroll_factor);
+    if (cl->is_main_loop() || cl->is_rce_post_loop()) {
+      cl->set_slp_max_unroll(local_loop_unroll_factor);
+    }
   }
 }
 

--- a/test/hotspot/jtreg/compiler/loopopts/TestUnreachableInnerLoop.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestUnreachableInnerLoop.java
@@ -1,0 +1,86 @@
+/*
+ * Copyright (c) 2022, Arm Limited. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/**
+ * @test
+ * @bug 8289954
+ * @summary C2: Assert failed in PhaseCFG::verify() after JDK-8183390
+ *
+ * @run main/othervm -Xcomp -Xbatch
+ *      -XX:CompileOnly=compiler/loopopts/TestUnreachableInnerLoop
+ *      compiler.loopopts.TestUnreachableInnerLoop
+ */
+
+package compiler.loopopts;
+
+public class TestUnreachableInnerLoop {
+
+    public static int field = 0;
+    public static int arr[] = new int[500];
+
+    public static void fun() {
+        for (int elem : arr) {
+            int x = 1, y = 2, z = 3;
+            int i, j;
+
+            // This is a good loop
+            for (i = 2; i < 63; i++) {
+                arr[i] = arr[i] + 3592870;
+            }
+
+            // The inner loop looks quite complex but it's unreachable
+            // code as loop condition "k < 2" never satisfies
+            for (j = 3; j < 63; j++) {
+                for (int k = j; k < 2; k++) {
+                    arr[j] <<= k;
+                    try {
+                        x = k / i;
+                        y = j % 6;
+                        arr[k] = 88 % elem;
+                    } catch (ArithmeticException ex) {}
+                    switch (2) {
+                        case 2: {
+                            try {
+                                y = arr[j] % y;
+                                z = x / 2345;
+                                elem = j % -2;
+                            } catch (ArithmeticException ex) {}
+                            break;
+                        }
+                        case 3: {
+                            y = arr[j] / 2;
+                            z -= k;
+                            break;
+                        }
+                    }
+                    arr[100] -= j;
+                    field += k;
+                }
+            }
+        }
+    }
+
+    public static void main(String[] args) {
+        fun();
+    }
+}


### PR DESCRIPTION
Fuzzer tests report an assertion failure issue in C2 global code motion
phase. Git bisection shows the problem starts after our fix of post loop
vectorization (JDK-8183390). After some narrowing down work, we find it
is caused by below change in that patch.

```
@@ -422,14 +404,7 @@
       cl->mark_passed_slp();
     }
     cl->mark_was_slp();
-    if (cl->is_main_loop()) {
-      cl->set_slp_max_unroll(local_loop_unroll_factor);
-    } else if (post_loop_allowed) {
-      if (!small_basic_type) {
-        // avoid replication context for small basic types in programmable masked loops
-        cl->set_slp_max_unroll(local_loop_unroll_factor);
-      }
-    }
+    cl->set_slp_max_unroll(local_loop_unroll_factor);
   }
 }
```

This change is in function `SuperWord::unrolling_analysis()`. AFAIK, it
helps find a loop's max unroll count via some analysis. In the original
code, we have loop type checks and the slp max unroll value is set for
only some types of loops. But in JDK-8183390, the check was removed by
mistake. In my current understanding, the slp max unroll value applies
to slp candidate loops only - either main loops or RCE'd post loops -
so that check shouldn't be removed. After restoring it we don't see the
assertion failure any more.

The new jtreg created in this patch can reproduce the failed assertion,
which checks `def_block->dominates(block)` - the domination relationship
of two blocks. But in the case, I found the blocks are in an unreachable
inner loop, which I think ought to be optimized away in some previous C2
phases. As I'm not quite familiar with the C2's global code motion, so
far I still don't understand how slp max unroll count eventually causes
that problem. This patch just restores the if condition which I removed
incorrectly in JDK-8183390. But I still suspect that there is another
hidden bug exists in C2. I would be glad if any reviewers can give me
some guidance or suggestions.

Tested hotspot::hotspot_all_no_apps, jdk::tier1~3 and langtools::tier1.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289954](https://bugs.openjdk.org/browse/JDK-8289954): C2: Assert failed in PhaseCFG::verify() after JDK-8183390


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Tobias Hartmann](https://openjdk.org/census#thartmann) (@TobiHartmann - **Reviewer**)
 * [Roland Westrelin](https://openjdk.org/census#roland) (@rwestrel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/130/head:pull/130` \
`$ git checkout pull/130`

Update a local copy of the PR: \
`$ git checkout pull/130` \
`$ git pull https://git.openjdk.org/jdk19 pull/130/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 130`

View PR using the GUI difftool: \
`$ git pr show -t 130`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/130.diff">https://git.openjdk.org/jdk19/pull/130.diff</a>

</details>
