### PR TITLE
8290071: Javadoc for MemorySegment/MemoryAddress getter/setters contains some typos

### DIFF
--- a/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemoryAddress.java
@@ -167,7 +167,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     }
 
     /**
-     * Reads a byte at the given offset from this address, with the given layout.
+     * Reads a byte from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -188,7 +188,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     byte get(ValueLayout.OfByte layout, long offset);
 
     /**
-     * Writes a byte at the given offset from this address, with the given layout.
+     * Writes a byte into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -209,7 +209,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfByte layout, long offset, byte value);
 
     /**
-     * Reads a boolean at the given offset from this address, with the given layout.
+     * Reads a boolean from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -230,7 +230,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     boolean get(ValueLayout.OfBoolean layout, long offset);
 
     /**
-     * Writes a boolean at the given offset from this address, with the given layout.
+     * Writes a boolean into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -251,7 +251,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfBoolean layout, long offset, boolean value);
 
     /**
-     * Reads a char at the given offset from this address, with the given layout.
+     * Reads a char from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -272,7 +272,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     char get(ValueLayout.OfChar layout, long offset);
 
     /**
-     * Writes a char at the given offset from this address, with the given layout.
+     * Writes a char into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -293,7 +293,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfChar layout, long offset, char value);
 
     /**
-     * Reads a short at the given offset from this address, with the given layout.
+     * Reads a short from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -314,7 +314,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     short get(ValueLayout.OfShort layout, long offset);
 
     /**
-     * Writes a short at the given offset from this address, with the given layout.
+     * Writes a short into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -335,7 +335,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfShort layout, long offset, short value);
 
     /**
-     * Reads an int at the given offset from this address, with the given layout.
+     * Reads an int from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -356,7 +356,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     int get(ValueLayout.OfInt layout, long offset);
 
     /**
-     * Writes an int at the given offset from this address, with the given layout.
+     * Writes an int into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -377,7 +377,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfInt layout, long offset, int value);
 
     /**
-     * Reads a float at the given offset from this address, with the given layout.
+     * Reads a float from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -398,7 +398,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     float get(ValueLayout.OfFloat layout, long offset);
 
     /**
-     * Writes a float at the given offset from this address, with the given layout.
+     * Writes a float into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -419,7 +419,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfFloat layout, long offset, float value);
 
     /**
-     * Reads a long at the given offset from this address, with the given layout.
+     * Reads a long from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -440,7 +440,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     long get(ValueLayout.OfLong layout, long offset);
 
     /**
-     * Writes a long at the given offset from this address, with the given layout.
+     * Writes a long into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -461,7 +461,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfLong layout, long offset, long value);
 
     /**
-     * Reads a double at the given offset from this address, with the given layout.
+     * Reads a double from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -482,7 +482,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     double get(ValueLayout.OfDouble layout, long offset);
 
     /**
-     * Writes a double at the given offset from this address, with the given layout.
+     * Writes a double into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -503,7 +503,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     void set(ValueLayout.OfDouble layout, long offset, double value);
 
     /**
-     * Reads an address at the given offset from this address, with the given layout.
+     * Reads an address from this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -524,7 +524,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     MemoryAddress get(ValueLayout.OfAddress layout, long offset);
 
     /**
-     * Writes an address at the given offset from this address, with the given layout.
+     * Writes an address into this address at the given offset, with the given layout.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -567,7 +567,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     char getAtIndex(ValueLayout.OfChar layout, long index);
 
     /**
-     * Writes a char to this address at the given index, scaled by the given layout size.
+     * Writes a char into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -611,7 +611,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     short getAtIndex(ValueLayout.OfShort layout, long index);
 
     /**
-     * Writes a short to this address at the given index, scaled by the given layout size.
+     * Writes a short into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -655,7 +655,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     int getAtIndex(ValueLayout.OfInt layout, long index);
 
     /**
-     * Writes an int to this address at the given index, scaled by the given layout size.
+     * Writes an int into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -699,7 +699,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     float getAtIndex(ValueLayout.OfFloat layout, long index);
 
     /**
-     * Writes a float to this address at the given index, scaled by the given layout size.
+     * Writes a float into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -743,7 +743,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     long getAtIndex(ValueLayout.OfLong layout, long index);
 
     /**
-     * Writes a long to this address at the given index, scaled by the given layout size.
+     * Writes a long into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -787,7 +787,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     double getAtIndex(ValueLayout.OfDouble layout, long index);
 
     /**
-     * Writes a double to this address at the given index, scaled by the given layout size.
+     * Writes a double into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash
@@ -831,7 +831,7 @@ public sealed interface MemoryAddress extends Addressable permits MemoryAddressI
     MemoryAddress getAtIndex(ValueLayout.OfAddress layout, long index);
 
     /**
-     * Writes an address to this address at the given index, scaled by the given layout size.
+     * Writes an address into this address at the given index, scaled by the given layout size.
      * <p>
      * This method is <a href="package-summary.html#restricted"><em>restricted</em></a>.
      * Restricted methods are unsafe, and, if used incorrectly, their use might crash

--- a/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
+++ b/src/java.base/share/classes/java/lang/foreign/MemorySegment.java
@@ -1077,7 +1077,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a byte at the given offset from this segment, with the given layout.
+     * Reads a byte from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1098,7 +1098,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a byte at the given offset from this segment, with the given layout.
+     * Writes a byte into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1120,7 +1120,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a boolean at the given offset from this segment, with the given layout.
+     * Reads a boolean from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1141,7 +1141,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a boolean at the given offset from this segment, with the given layout.
+     * Writes a boolean into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1163,7 +1163,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a char at the given offset from this segment, with the given layout.
+     * Reads a char from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1184,7 +1184,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a char at the given offset from this segment, with the given layout.
+     * Writes a char into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1206,7 +1206,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a short at the given offset from this segment, with the given layout.
+     * Reads a short from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1227,7 +1227,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a short at the given offset from this segment, with the given layout.
+     * Writes a short into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1249,7 +1249,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads an int at the given offset from this segment, with the given layout.
+     * Reads an int from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1270,7 +1270,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes an int at the given offset from this segment, with the given layout.
+     * Writes an int into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1292,7 +1292,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a float at the given offset from this segment, with the given layout.
+     * Reads a float from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1313,7 +1313,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a float at the given offset from this segment, with the given layout.
+     * Writes a float into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1335,7 +1335,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a long at the given offset from this segment, with the given layout.
+     * Reads a long from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1356,7 +1356,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a long at the given offset from this segment, with the given layout.
+     * Writes a long into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1378,7 +1378,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads a double at the given offset from this segment, with the given layout.
+     * Reads a double from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1399,7 +1399,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a double at the given offset from this segment, with the given layout.
+     * Writes a double into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1421,7 +1421,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Reads an address at the given offset from this segment, with the given layout.
+     * Reads an address from this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be read.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1442,7 +1442,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes an address at the given offset from this segment, with the given layout.
+     * Writes an address into this segment at the given offset, with the given layout.
      *
      * @param layout the layout of the memory region to be written.
      * @param offset offset in bytes (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1488,7 +1488,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a char to this segment at the given index, scaled by the given layout size.
+     * Writes a char into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1537,7 +1537,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a short to this segment at the given index, scaled by the given layout size.
+     * Writes a short into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1586,7 +1586,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes an int to this segment at the given index, scaled by the given layout size.
+     * Writes an int into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1635,7 +1635,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a float to this segment at the given index, scaled by the given layout size.
+     * Writes a float into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1684,7 +1684,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a long to this segment at the given index, scaled by the given layout size.
+     * Writes a long into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1733,7 +1733,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes a double to this segment at the given index, scaled by the given layout size.
+     * Writes a double into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,
@@ -1782,7 +1782,7 @@ public sealed interface MemorySegment extends Addressable permits AbstractMemory
     }
 
     /**
-     * Writes an address to this segment at the given index, scaled by the given layout size.
+     * Writes an address into this segment at the given index, scaled by the given layout size.
      *
      * @param layout the layout of the memory region to be written.
      * @param index index (relative to this segment). For instance, if this segment is a {@linkplain #isNative() native} segment,


### PR DESCRIPTION
Some of the accessors in `MemorySegment` and `MemoryAddress` (esp. setters) have typos - e.g. they use `from` instead of `into`.

I've tried to simplify the text and made it more regular.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290071](https://bugs.openjdk.org/browse/JDK-8290071): Javadoc for MemorySegment/MemoryAddress getter/setters contains some typos


### Reviewers
 * [Uwe Schindler](https://openjdk.org/census#uschindler) (@uschindler - Author)
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/131/head:pull/131` \
`$ git checkout pull/131`

Update a local copy of the PR: \
`$ git checkout pull/131` \
`$ git pull https://git.openjdk.org/jdk19 pull/131/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 131`

View PR using the GUI difftool: \
`$ git pr show -t 131`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/131.diff">https://git.openjdk.org/jdk19/pull/131.diff</a>

</details>
