### PR TITLE
8288850: SegmentAllocator:allocate() can return null some cases

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/ArenaAllocator.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/ArenaAllocator.java
@@ -78,7 +78,9 @@ public final class ArenaAllocator implements SegmentAllocator {
             return slice;
         } else {
             long maxPossibleAllocationSize = bytesSize + bytesAlignment - 1;
-            if (maxPossibleAllocationSize > blockSize) {
+            if (maxPossibleAllocationSize < 0) {
+                throw new OutOfMemoryError();
+            } else if (maxPossibleAllocationSize > blockSize) {
                 // too big
                 return newSegment(bytesSize, bytesAlignment);
             } else {

--- a/test/jdk/java/foreign/TestSegmentAllocators.java
+++ b/test/jdk/java/foreign/TestSegmentAllocators.java
@@ -160,6 +160,12 @@ public class TestSegmentAllocators {
         allocator.allocate(1, 3);
     }
 
+    @Test(expectedExceptions = OutOfMemoryError.class)
+    public void testBadArenaNullReturn() {
+        SegmentAllocator segmentAllocator = SegmentAllocator.newNativeArena(MemorySession.openImplicit());
+        segmentAllocator.allocate(Long.MAX_VALUE, 2);
+    }
+
     @Test
     public void testArrayAllocateDelegation() {
         AtomicInteger calls = new AtomicInteger();


### PR DESCRIPTION
This patch fixes an issue where the arena allocator does not detect an overflow when attempting to allocate a new slice.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288850](https://bugs.openjdk.org/browse/JDK-8288850): SegmentAllocator:allocate() can return null some cases


### Reviewers
 * [Paul Sandoz](https://openjdk.org/census#psandoz) (@PaulSandoz - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/133/head:pull/133` \
`$ git checkout pull/133`

Update a local copy of the PR: \
`$ git checkout pull/133` \
`$ git pull https://git.openjdk.org/jdk19 pull/133/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 133`

View PR using the GUI difftool: \
`$ git pr show -t 133`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/133.diff">https://git.openjdk.org/jdk19/pull/133.diff</a>

</details>
