### PR TITLE
8287902: UnreadableRB case in MissingResourceCauseTest is not working reliably on Windows

### DIFF
--- a/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTest.java
+++ b/test/jdk/java/util/ResourceBundle/Control/MissingResourceCauseTest.java
@@ -34,7 +34,9 @@ public class MissingResourceCauseTest {
         callGetBundle("PrivateConstructorRB", IllegalAccessException.class);
         callGetBundle("AbstractRB", InstantiationException.class);
         callGetBundle("BadStaticInitRB", ExceptionInInitializerError.class);
-        callGetBundle("UnreadableRB", IOException.class);
+        if (!System.getProperty("os.name").toLowerCase().startsWith("win")) {
+            callGetBundle("UnreadableRB", IOException.class);
+        }
         callGetBundle("NoNoArgConstructorRB", InstantiationException.class);
     }
 


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8287902](https://bugs.openjdk.org/browse/JDK-8287902), commit [975316e3](https://github.com/openjdk/jdk/commit/975316e3e5f1208e4e15eadc2493d25c15554647) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

The commit being backported was authored by Magnus Ihse Bursie on 10 Jun 2022 and was reviewed by Naoto Sato.

It fixes an issue that shows up in the new GHA workflow.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8287902](https://bugs.openjdk.org/browse/JDK-8287902): UnreadableRB case in MissingResourceCauseTest is not working reliably on Windows


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/134/head:pull/134` \
`$ git checkout pull/134`

Update a local copy of the PR: \
`$ git checkout pull/134` \
`$ git pull https://git.openjdk.org/jdk19 pull/134/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 134`

View PR using the GUI difftool: \
`$ git pr show -t 134`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/134.diff">https://git.openjdk.org/jdk19/pull/134.diff</a>

</details>
