### PR TITLE
8290201: ProblemList com/sun/jdi/InvokeHangTest.java on macosx-x64 in vthread mode

### DIFF
--- a/test/jdk/ProblemList-svc-vthread.txt
+++ b/test/jdk/ProblemList-svc-vthread.txt
@@ -1,3 +1,25 @@
+#
+# Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+# DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+#
+# This code is free software; you can redistribute it and/or modify it
+# under the terms of the GNU General Public License version 2 only, as
+# published by the Free Software Foundation.
+#
+# This code is distributed in the hope that it will be useful, but WITHOUT
+# ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# version 2 for more details (a copy is included in the LICENSE file that
+# accompanied this code).
+#
+# You should have received a copy of the GNU General Public License version
+# 2 along with this work; if not, write to the Free Software Foundation,
+# Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+#
+# Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+# or visit www.oracle.com if you need additional information or have any
+# questions.
+#
 
 com/sun/jdi/EATests.java#id0                                    8264699 generic-all
 
@@ -33,6 +55,8 @@ com/sun/jdi/StepTest.java 8285422 generic-all
 com/sun/jdi/redefine/RedefineTest.java 8285422 generic-all
 com/sun/jdi/redefineMethod/RedefineTest.java 8285422 generic-all
 
+com/sun/jdi/InvokeHangTest.java 8290200 macosx-x64
+
 ####
 # JDI SDE Tests
 # Use custom classpath
@@ -42,5 +66,3 @@ com/sun/jdi/sde/MangleTest.java 8285423 generic-all
 com/sun/jdi/sde/MangleStepTest.java 8285423 generic-all
 com/sun/jdi/sde/TemperatureTableTest.java 8285423 generic-all
 com/sun/jdi/sde/SourceDebugExtensionTest.java 8285423 generic-all
-
-com/sun/jdi/EATests.java#id0 8264699 generic-all


### PR DESCRIPTION
A trivial fix to ProblemList com/sun/jdi/InvokeHangTest.java on macosx-x64 in vthread mode.

The copyright header is missing in this ProblemList file and there is a duplicate entry. 
I'm fixing those also as long as I'm here.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290201](https://bugs.openjdk.org/browse/JDK-8290201): ProblemList com/sun/jdi/InvokeHangTest.java on macosx-x64 in vthread mode


### Reviewers
 * [Brian Burkhalter](https://openjdk.org/census#bpb) (@bplb - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/136/head:pull/136` \
`$ git checkout pull/136`

Update a local copy of the PR: \
`$ git checkout pull/136` \
`$ git pull https://git.openjdk.org/jdk19 pull/136/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 136`

View PR using the GUI difftool: \
`$ git pr show -t 136`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/136.diff">https://git.openjdk.org/jdk19/pull/136.diff</a>

</details>
