### PR TITLE
8290250: Shenandoah: disable Loom for iu mode

### DIFF
--- a/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
+++ b/src/hotspot/share/gc/shenandoah/mode/shenandoahIUMode.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2020, 2021, Red Hat, Inc. All rights reserved.
+ * Copyright (c) 2020, 2022, Red Hat, Inc. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -50,6 +50,9 @@ void ShenandoahIUMode::initialize_flags() const {
   if (FLAG_IS_DEFAULT(ShenandoahSATBBarrier)) {
     FLAG_SET_DEFAULT(ShenandoahSATBBarrier, false);
   }
+
+  // Disable Loom
+  SHENANDOAH_ERGO_DISABLE_FLAG(VMContinuations);
 
   SHENANDOAH_ERGO_ENABLE_FLAG(ExplicitGCInvokesConcurrent);
   SHENANDOAH_ERGO_ENABLE_FLAG(ShenandoahImplicitGCInvokesConcurrent);


### PR DESCRIPTION
Please review this trivial patch to disable Loom for Shenandoah iu mode (an experimental feature).

Test:
- [x] hotspot_gc_shenandoah
- [x] jdk_loom with Shenandoah + iu
- [x] hotspot_loom with Shenandoah + iu

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290250](https://bugs.openjdk.org/browse/JDK-8290250): Shenandoah: disable Loom for iu mode


### Reviewers
 * [Roman Kennke](https://openjdk.org/census#rkennke) (@rkennke - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/140/head:pull/140` \
`$ git checkout pull/140`

Update a local copy of the PR: \
`$ git checkout pull/140` \
`$ git pull https://git.openjdk.org/jdk19 pull/140/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 140`

View PR using the GUI difftool: \
`$ git pr show -t 140`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/140.diff">https://git.openjdk.org/jdk19/pull/140.diff</a>

</details>
