### PR TITLE
8289127: Apache Lucene triggers: DEBUG MESSAGE: duplicated predicate failed which is impossible

### DIFF
--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1450,6 +1450,7 @@ bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
   }
   assert(init == verif_init && stride == verif_stride, "missed opaque node");
 #endif
+  assert(stride == 0 || init != 0, "init should be there every time stride is");
   return init != 0;
 }
 

--- a/src/hotspot/share/opto/loopTransform.cpp
+++ b/src/hotspot/share/opto/loopTransform.cpp
@@ -1390,6 +1390,7 @@ static bool skeleton_follow_inputs(Node* n, int op) {
           op == Op_OrL ||
           op == Op_RShiftL ||
           op == Op_LShiftL ||
+          op == Op_LShiftI ||
           op == Op_AddL ||
           op == Op_AddI ||
           op == Op_MulL ||
@@ -1404,6 +1405,8 @@ bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
   ResourceMark rm;
   Unique_Node_List wq;
   wq.push(iff->in(1)->in(1));
+  uint init = 0;
+  uint stride = 0;
   for (uint i = 0; i < wq.size(); i++) {
     Node* n = wq.at(i);
     int op = n->Opcode();
@@ -1416,11 +1419,38 @@ bool PhaseIdealLoop::skeleton_predicate_has_opaque(IfNode* iff) {
       }
       continue;
     }
-    if (n->is_Opaque1()) {
-      return true;
+    if (n->Opcode() == Op_OpaqueLoopInit) {
+      init++;
+    } else if (n->Opcode() == Op_OpaqueLoopStride) {
+      stride++;
     }
   }
-  return false;
+#ifdef ASSERT
+  wq.clear();
+  wq.push(iff->in(1)->in(1));
+  uint verif_init = 0;
+  uint verif_stride = 0;
+  for (uint i = 0; i < wq.size(); i++) {
+    Node* n = wq.at(i);
+    int op = n->Opcode();
+    if (!n->is_CFG()) {
+      if (n->Opcode() == Op_OpaqueLoopInit) {
+        verif_init++;
+      } else if (n->Opcode() == Op_OpaqueLoopStride) {
+        verif_stride++;
+      } else {
+        for (uint j = 1; j < n->req(); j++) {
+          Node* m = n->in(j);
+          if (m != NULL) {
+            wq.push(m);
+          }
+        }
+      }
+    }
+  }
+  assert(init == verif_init && stride == verif_stride, "missed opaque node");
+#endif
+  return init != 0;
 }
 
 // Clone the skeleton predicate bool for a main or unswitched loop:

--- a/test/hotspot/jtreg/compiler/loopopts/TestMissedOpaqueInPredicate.java
+++ b/test/hotspot/jtreg/compiler/loopopts/TestMissedOpaqueInPredicate.java
@@ -1,0 +1,52 @@
+/*
+ * Copyright (c) 2022, Red Hat, Inc. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @bug 8289127
+ * @summary Apache Lucene triggers: DEBUG MESSAGE: duplicated predicate failed which is impossible
+ * @run main/othervm -XX:-BackgroundCompilation -XX:-UseOnStackReplacement -XX:-TieredCompilation TestMissedOpaqueInPredicate
+ */
+
+public class TestMissedOpaqueInPredicate {
+    public static void main(String[] args) {
+        long[] tmp = new long[28];
+        long[] longs = new long[32];
+        for (int i = 0; i < 20_000; i++) {
+            test(tmp, longs);
+        }
+    }
+
+    private static void test(long[] tmp, long[] longs) {
+        for (int iter = 0, tmpIdx = 0, longsIdx = 28; iter < 4; ++iter, tmpIdx += 7, longsIdx += 1) {
+            long l0 = tmp[tmpIdx + 0] << 12;
+            l0 |= tmp[tmpIdx + 1] << 10;
+            l0 |= tmp[tmpIdx + 2] << 8;
+            l0 |= tmp[tmpIdx + 3] << 6;
+            l0 |= tmp[tmpIdx + 4] << 4;
+            l0 |= tmp[tmpIdx + 5] << 2;
+            l0 |= tmp[tmpIdx + 6] << 0;
+            longs[longsIdx + 0] = l0;
+        }
+    }
+}


### PR DESCRIPTION
Loop predication adds a skeleton predicate for a range check that computes:

(AddL (ConvI2L (MulI (CastII (AddI (OpaqueLoopInit 0) (SubI (OpaqueLoopStride ..) 1))) 7))  ..)

later transformed into:

(AddL (SubL (ConvI2L (LShiftI (CastII (AddI (OpaqueLoopInit 0) (OpaqueLoopStride ..))) 3)) (AddL (ConvI2L (CastII (AddI (OpaqueLoopInit 0) (OpaqueLoopStride ..)))) -1)) ..)

When pre/main/post loops are added, this expression is copied (above
the main loop) and updated. The logic performing the copy relies on
skeleton_follow_inputs() to find the OpaqueLoopInit nodes and clone it
with an updated initial value. Note there are 2 OpaqueLoopInit nodes
to update in the transformed expression. But because
skeleton_follow_inputs() doesn't include LShiftI only one of the
OpaqueLoopInit node is cloned with an updated initial value.

After loop opts are over, the OpaqueLoopInit nodes are replaced by
their input which result in this particular case in a predicate that
always fails.

The fix is to fix skeleton_follow_inputs() to include LShiftI. I also
added verification code to catch similar issues in the future.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8289127](https://bugs.openjdk.org/browse/JDK-8289127): Apache Lucene triggers: DEBUG MESSAGE: duplicated predicate failed which is impossible


### Reviewers
 * [Vladimir Kozlov](https://openjdk.org/census#kvn) (@vnkozlov - **Reviewer**)
 * [Dean Long](https://openjdk.org/census#dlong) (@dean-long - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/143/head:pull/143` \
`$ git checkout pull/143`

Update a local copy of the PR: \
`$ git checkout pull/143` \
`$ git pull https://git.openjdk.org/jdk19 pull/143/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 143`

View PR using the GUI difftool: \
`$ git pr show -t 143`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/143.diff">https://git.openjdk.org/jdk19/pull/143.diff</a>

</details>
