### PR TITLE
8288482: JFR: Cannot resolve method

### DIFF
--- a/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
+++ b/src/hotspot/share/jfr/recorder/checkpoint/types/jfrTypeSet.cpp
@@ -197,7 +197,9 @@ static void set_serialized(const T* ptr) {
   assert(ptr != NULL, "invariant");
   SET_SERIALIZED(ptr);
   assert(IS_SERIALIZED(ptr), "invariant");
-  CLEAR_THIS_EPOCH_CLEARED_BIT(ptr);
+  if (current_epoch()) {
+    CLEAR_THIS_EPOCH_CLEARED_BIT(ptr);
+  }
 }
 
 /*
@@ -775,7 +777,9 @@ void set_serialized<Method>(MethodPtr method) {
   assert(method != NULL, "invariant");
   SET_METHOD_SERIALIZED(method);
   assert(IS_METHOD_SERIALIZED(method), "invariant");
-  CLEAR_THIS_EPOCH_METHOD_CLEARED_BIT(method);
+  if (current_epoch()) {
+    CLEAR_THIS_EPOCH_METHOD_CLEARED_BIT(method);
+  }
 }
 
 static int write_method(JfrCheckpointWriter* writer, MethodPtr method, bool leakp) {


### PR DESCRIPTION
Greetings,

Serializations related to rotations must not issue the CLEAR_THIS_EPOCH_METHOD_CLEARED_BIT because, at this point, the epoch has already shifted. As such, we are collecting the previous epoch and must not clear the current one.
CLEAR_THIS_EPOCH_METHOD_CLEARED_BIT is only valid for flushpoints and class unloading, which collects the current epoch. 
Please see the description in the JIRA issue for additional details.

Testing: Repro.java, jdk_jfr

Thanks
Markus

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8288482](https://bugs.openjdk.org/browse/JDK-8288482): JFR: Cannot resolve method


### Reviewers
 * [Jaroslav Bachorik](https://openjdk.org/census#jbachorik) (@jbachorik - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/144/head:pull/144` \
`$ git checkout pull/144`

Update a local copy of the PR: \
`$ git checkout pull/144` \
`$ git pull https://git.openjdk.org/jdk19 pull/144/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 144`

View PR using the GUI difftool: \
`$ git pr show -t 144`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/144.diff">https://git.openjdk.org/jdk19/pull/144.diff</a>

</details>
