### PR TITLE
8290625: Test jdk/javadoc/tool/CheckManPageOptions.java after manpage update

### DIFF
--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -66,7 +66,7 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    List<String> MISSING_IN_MAN_PAGE = List.of("");
+    List<String> MISSING_IN_MAN_PAGE = List.of();
 
     void run(String... args) throws Exception {
         var file = args.length == 0 ? findDefaultFile() : Path.of(args[0]);

--- a/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
+++ b/test/langtools/jdk/javadoc/tool/CheckManPageOptions.java
@@ -66,7 +66,7 @@ public class CheckManPageOptions {
 
     static final PrintStream out = System.err;
 
-    List<String> MISSING_IN_MAN_PAGE = List.of("--date");
+    List<String> MISSING_IN_MAN_PAGE = List.of("");
 
     void run(String... args) throws Exception {
         var file = args.length == 0 ? findDefaultFile() : Path.of(args[0]);


### PR DESCRIPTION
[JDK-8278274](https://bugs.openjdk.org/browse/JDK-8278274) just brought the nroff manpage into sync with its markdown source. But this test examines the nroff manpage and needs to be updated as the `--date` option is no longer missing.

Thanks.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290625](https://bugs.openjdk.org/browse/JDK-8290625): Test jdk/javadoc/tool/CheckManPageOptions.java after manpage update


### Reviewers
 * [Hannes Wallnöfer](https://openjdk.org/census#hannesw) (@hns - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/149/head:pull/149` \
`$ git checkout pull/149`

Update a local copy of the PR: \
`$ git checkout pull/149` \
`$ git pull https://git.openjdk.org/jdk19 pull/149/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 149`

View PR using the GUI difftool: \
`$ git pr show -t 149`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/149.diff">https://git.openjdk.org/jdk19/pull/149.diff</a>

</details>
