### PR TITLE
8290455: jck test api/java_lang/foreign/VaList/Empty.html fails on some platforms

### DIFF
--- a/src/java.base/share/classes/jdk/internal/foreign/CABI.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/CABI.java
@@ -34,34 +34,41 @@ public enum CABI {
     LinuxAArch64,
     MacOsAArch64;
 
-    private static final CABI current;
+    private static final CABI ABI;
+    private static final String ARCH;
+    private static final String OS;
+    private static final long ADDRESS_SIZE;
 
     static {
-        String arch = privilegedGetProperty("os.arch");
-        String os = privilegedGetProperty("os.name");
-        long addressSize = ADDRESS.bitSize();
+        ARCH = privilegedGetProperty("os.arch");
+        OS = privilegedGetProperty("os.name");
+        ADDRESS_SIZE = ADDRESS.bitSize();
         // might be running in a 32-bit VM on a 64-bit platform.
         // addressSize will be correctly 32
-        if ((arch.equals("amd64") || arch.equals("x86_64")) && addressSize == 64) {
-            if (os.startsWith("Windows")) {
-                current = Win64;
+        if ((ARCH.equals("amd64") || ARCH.equals("x86_64")) && ADDRESS_SIZE == 64) {
+            if (OS.startsWith("Windows")) {
+                ABI = Win64;
             } else {
-                current = SysV;
+                ABI = SysV;
             }
-        } else if (arch.equals("aarch64")) {
-            if (os.startsWith("Mac")) {
-                current = MacOsAArch64;
+        } else if (ARCH.equals("aarch64")) {
+            if (OS.startsWith("Mac")) {
+                ABI = MacOsAArch64;
             } else {
                 // The Linux ABI follows the standard AAPCS ABI
-                current = LinuxAArch64;
+                ABI = LinuxAArch64;
             }
         } else {
-            throw new UnsupportedOperationException(
-                "Unsupported os, arch, or address size: " + os + ", " + arch + ", " + addressSize);
+            // unsupported
+            ABI = null;
         }
     }
 
     public static CABI current() {
-        return current;
+        if (ABI == null) {
+            throw new UnsupportedOperationException(
+                    "Unsupported os, arch, or address size: " + OS + ", " + ARCH + ", " + ADDRESS_SIZE);
+        }
+        return ABI;
     }
 }

--- a/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
+++ b/src/java.base/share/classes/jdk/internal/foreign/PlatformLayouts.java
@@ -29,13 +29,6 @@ import java.lang.foreign.MemoryLayout;
 import java.lang.foreign.ValueLayout;
 
 public class PlatformLayouts {
-    public static <Z extends MemoryLayout> Z pick(Z sysv, Z win64, Z aarch64) {
-        return switch (CABI.current()) {
-            case SysV -> sysv;
-            case Win64 -> win64;
-            case LinuxAArch64, MacOsAArch64 -> aarch64;
-        };
-    }
 
     /**
      * This class defines layout constants modelling standard primitive types supported by the x64 SystemV ABI.

--- a/test/jdk/java/foreign/TestUnsupportedLinker.java
+++ b/test/jdk/java/foreign/TestUnsupportedLinker.java
@@ -1,0 +1,60 @@
+/*
+ * Copyright (c) 2022, Oracle and/or its affiliates. All rights reserved.
+ * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
+ *
+ * This code is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU General Public License version 2 only, as
+ * published by the Free Software Foundation.
+ *
+ * This code is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or
+ * FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+ * version 2 for more details (a copy is included in the LICENSE file that
+ * accompanied this code).
+ *
+ * You should have received a copy of the GNU General Public License version
+ * 2 along with this work; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA.
+ *
+ * Please contact Oracle, 500 Oracle Parkway, Redwood Shores, CA 94065 USA
+ * or visit www.oracle.com if you need additional information or have any
+ * questions.
+ */
+
+/*
+ * @test
+ * @enablePreview
+ *
+ * @run testng/othervm -Dos.arch=unknown -Dos.name=unknown --enable-native-access=ALL-UNNAMED TestUnsupportedLinker
+ */
+
+import java.lang.foreign.Linker;
+import java.lang.foreign.MemoryAddress;
+import java.lang.foreign.MemorySession;
+import java.lang.foreign.VaList;
+import java.lang.foreign.ValueLayout;
+
+import org.testng.annotations.Test;
+
+public class TestUnsupportedLinker {
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testLinker() {
+        Linker.nativeLinker();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testEmptyVaList() {
+        VaList.empty();
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testNonEmptyVaList() {
+        VaList.make(builder -> builder.addVarg(ValueLayout.JAVA_INT, 42), MemorySession.openImplicit());
+    }
+
+    @Test(expectedExceptions = UnsupportedOperationException.class)
+    public void testUnsafeVaList() {
+        VaList.ofAddress(MemoryAddress.NULL, MemorySession.openImplicit());
+    }
+}


### PR DESCRIPTION
The javadoc for `Linker` states that some operations throw `UnsupportedOperationException` when called on an unsupported platform. These operations are:

* `Linker::nativeLinker`
* `VaList::empty`
* `VaList::make`
* `VaList::ofAddress`

While the code throws an UOE as required, since the exception is thrown in a static initialized, it gets wrapped in an `ExceptionInInitializerError`.

The solution is to set the `CABI` value to `null` if the platform is unknown. Then, when clients call the `CABI.current()` method, we can throw at that point, which will result in the behavior requested by the API spec.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290455](https://bugs.openjdk.org/browse/JDK-8290455): jck test api/java_lang/foreign/VaList/Empty.html fails on some platforms


### Reviewers
 * [Jorn Vernee](https://openjdk.org/census#jvernee) (@JornVernee - **Reviewer**)
 * [Matthias Baesken](https://openjdk.org/census#mbaesken) (@MBaesken - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/150/head:pull/150` \
`$ git checkout pull/150`

Update a local copy of the PR: \
`$ git checkout pull/150` \
`$ git pull https://git.openjdk.org/jdk19 pull/150/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 150`

View PR using the GUI difftool: \
`$ git pr show -t 150`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/150.diff">https://git.openjdk.org/jdk19/pull/150.diff</a>

</details>
