### PR TITLE
8290460: Alpine: disable some panama tests that rely on std::thread

### DIFF
--- a/test/jdk/java/foreign/TestUpcallAsync.java
+++ b/test/jdk/java/foreign/TestUpcallAsync.java
@@ -25,6 +25,7 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires !vm.musl
  * @build NativeTestHelper CallGeneratorHelper TestUpcallBase
  *
  * @run testng/othervm -XX:+IgnoreUnrecognizedVMOptions -XX:-VerifyDependencies

--- a/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
+++ b/test/jdk/java/foreign/enablenativeaccess/TestEnableNativeAccess.java
@@ -25,6 +25,8 @@
  * @test
  * @enablePreview
  * @requires ((os.arch == "amd64" | os.arch == "x86_64") & sun.arch.data.model == "64") | os.arch == "aarch64"
+ * @requires !vm.musl
+ *
  * @library /test/lib
  * @build TestEnableNativeAccess
  *        panama_module/*


### PR DESCRIPTION
Hi all,

This pull request contains a backport of [JDK-8290460](https://bugs.openjdk.org/browse/JDK-8290460), commit [d7f0de27](https://github.com/openjdk/jdk/commit/d7f0de272c85ee8d0890c9d61e10065b618b69d7) from the [openjdk/jdk](https://git.openjdk.org/jdk) repository.

It is a testfix, so should be good to submit within RDP2. The issue is observed in SAP's CI.

Thanks!

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290460](https://bugs.openjdk.org/browse/JDK-8290460): Alpine: disable some panama tests that rely on std::thread


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/151/head:pull/151` \
`$ git checkout pull/151`

Update a local copy of the PR: \
`$ git checkout pull/151` \
`$ git pull https://git.openjdk.org/jdk19 pull/151/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 151`

View PR using the GUI difftool: \
`$ git pr show -t 151`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/151.diff">https://git.openjdk.org/jdk19/pull/151.diff</a>

</details>
