### PR TITLE
8290867: Race freeing remembered set segments

### DIFF
--- a/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
@@ -27,6 +27,7 @@
 #include "gc/g1/g1SegmentedArray.inline.hpp"
 #include "memory/allocation.hpp"
 #include "runtime/atomic.hpp"
+#include "runtime/vmOperations.hpp"
 #include "utilities/globalCounter.inline.hpp"
 
 G1SegmentedArraySegment::G1SegmentedArraySegment(uint slot_size, uint num_slots, G1SegmentedArraySegment* next, MEMFLAGS flag) :
@@ -48,8 +49,11 @@ G1SegmentedArraySegment* G1SegmentedArraySegment::create_segment(uint slot_size,
 }
 
 void G1SegmentedArraySegment::delete_segment(G1SegmentedArraySegment* segment) {
-  // Wait for concurrent readers of the segment to exit before freeing.
-  GlobalCounter::write_synchronize();
+  // Wait for concurrent readers of the segment to exit before freeing; but only if the VM
+  // isn't exiting.
+  if (!VM_Exit::vm_exited()) {
+    GlobalCounter::write_synchronize();
+  }
   segment->~G1SegmentedArraySegment();
   FREE_C_HEAP_ARRAY(_mem_flag, segment);
 }

--- a/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
+++ b/src/hotspot/share/gc/g1/g1SegmentedArray.cpp
@@ -48,6 +48,8 @@ G1SegmentedArraySegment* G1SegmentedArraySegment::create_segment(uint slot_size,
 }
 
 void G1SegmentedArraySegment::delete_segment(G1SegmentedArraySegment* segment) {
+  // Wait for concurrent readers of the segment to exit before freeing.
+  GlobalCounter::write_synchronize();
   segment->~G1SegmentedArraySegment();
   FREE_C_HEAP_ARRAY(_mem_flag, segment);
 }


### PR DESCRIPTION
Hi all,

  please review this fix for a crash due to a race in remembered set segment deallocation. Here is the description (provided by chaeubl as reported):

 - Thread A executes `G1SegmentedArray::create_new_segment` and tries to pop an element from the `_free_segment_list`. For that, thread A executes `LockFreeStack::pop()`
- Thread A reads `LockFreeStack::top()`
- Thread B executes `LockFreeStack::pop()`, also reads `LockFreeStack::top()` and pops that element from the stack
- Thread B executes `Atomic::cmpxchg(&_first, prev, next);` in `G1SegmentedArray::create_new_segment` but it fails because another thread already registered a different segment
- Thread B calls `G1SegmentedArraySegment::delete_segment` and frees the value
- Thread A tries to access `top()->next` in `LockFreeStack::pop()`, which causes a segfault because `top()` was freed by thread B 

The fix is to delay the deletion of that memory segment until all readers (i.e. in `G1SegmentedArrayFreeList::get` calling `_list.pop()`) drop the references to that memory segment. The readers are already guarded by a `CriticalSection`.

Testing: tier1-5 running, reproducer that adds extra delays that significantly delays to widen the opportunity this race can occur passes on BigRAMTester (otherwise crashes in a few seconds)

Thanks,
  Thomas

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290867](https://bugs.openjdk.org/browse/JDK-8290867): Race freeing remembered set segments


### Reviewers
 * [Kim Barrett](https://openjdk.org/census#kbarrett) (@kimbarrett - **Reviewer**) ⚠️ Review applies to [2ec1d209](https://git.openjdk.org/jdk19/pull/152/files/2ec1d209956f3f414473abc74cbafc7195a70be6)
 * [Sangheon Kim](https://openjdk.org/census#sangheki) (@sangheon - **Reviewer**) ⚠️ Review applies to [2ec1d209](https://git.openjdk.org/jdk19/pull/152/files/2ec1d209956f3f414473abc74cbafc7195a70be6)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/152/head:pull/152` \
`$ git checkout pull/152`

Update a local copy of the PR: \
`$ git checkout pull/152` \
`$ git pull https://git.openjdk.org/jdk19 pull/152/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 152`

View PR using the GUI difftool: \
`$ git pr show -t 152`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/152.diff">https://git.openjdk.org/jdk19/pull/152.diff</a>

</details>
