### PR TITLE
8291512: Snippetize modules API examples

### DIFF
--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -122,7 +122,7 @@ import sun.security.util.SecurityConstants;
  * in this class causes a {@link NullPointerException NullPointerException} to
  * be thrown. </p>
  *
- * <h2> Example usage: </h2>
+ * <h2> Example </h2>
  *
  * <p> This example creates a configuration by resolving a module named
  * "{@code myapp}" with the configuration for the boot layer as the parent. It

--- a/src/java.base/share/classes/java/lang/ModuleLayer.java
+++ b/src/java.base/share/classes/java/lang/ModuleLayer.java
@@ -129,19 +129,15 @@ import sun.security.util.SecurityConstants;
  * then creates a new layer with the modules in this configuration. All modules
  * are defined to the same class loader. </p>
  *
- * <pre>{@code
+ * {@snippet :
  *     ModuleFinder finder = ModuleFinder.of(dir1, dir2, dir3);
- *
  *     ModuleLayer parent = ModuleLayer.boot();
- *
- *     Configuration cf = parent.configuration().resolve(finder, ModuleFinder.of(), Set.of("myapp"));
- *
+ *     Configuration cf = parent.configuration()
+ *                              .resolve(finder, ModuleFinder.of(), Set.of("myapp"));
  *     ClassLoader scl = ClassLoader.getSystemClassLoader();
- *
  *     ModuleLayer layer = parent.defineModulesWithOneLoader(cf, scl);
- *
  *     Class<?> c = layer.findLoader("myapp").loadClass("app.Main");
- * }</pre>
+ * }
  *
  * @since 9
  * @see Module#getLayer()

--- a/src/java.base/share/classes/java/lang/module/Configuration.java
+++ b/src/java.base/share/classes/java/lang/module/Configuration.java
@@ -83,11 +83,10 @@ import jdk.internal.vm.annotation.Stable;
  * parent configuration. It prints the name of each resolved module and the
  * names of the modules that each module reads. </p>
  *
- * <pre>{@code
+ * {@snippet :
+ *    Path dir1 = ..., dir2 = ..., dir3 = ...;
  *    ModuleFinder finder = ModuleFinder.of(dir1, dir2, dir3);
- *
  *    Configuration parent = ModuleLayer.boot().configuration();
- *
  *    Configuration cf = parent.resolve(finder, ModuleFinder.of(), Set.of("myapp"));
  *    cf.modules().forEach(m -> {
  *        System.out.format("%s -> %s%n",
@@ -96,7 +95,7 @@ import jdk.internal.vm.annotation.Stable;
  *                .map(ResolvedModule::name)
  *                .collect(Collectors.joining(", ")));
  *    });
- * }</pre>
+ * }
  *
  * @since 9
  * @see java.lang.ModuleLayer

--- a/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleDescriptor.java
@@ -1467,13 +1467,14 @@ public class ModuleDescriptor
      * <cite>The Java Language Specification</cite>. </p>
      *
      * <p> Example usage: </p>
-     * <pre>{@code    ModuleDescriptor descriptor = ModuleDescriptor.newModule("stats.core")
+     * {@snippet :
+     *     ModuleDescriptor descriptor = ModuleDescriptor.newModule("stats.core")
      *         .requires("java.base")
      *         .exports("org.acme.stats.core.clustering")
      *         .exports("org.acme.stats.core.regression")
      *         .packages(Set.of("org.acme.stats.core.internal"))
      *         .build();
-     * }</pre>
+     * }
      *
      * @apiNote A {@code Builder} checks the components and invariants as
      * components are added to the builder. The rationale for this is to detect

--- a/src/java.base/share/classes/java/lang/module/ModuleFinder.java
+++ b/src/java.base/share/classes/java/lang/module/ModuleFinder.java
@@ -54,15 +54,12 @@ import jdk.internal.module.SystemModuleFinders;
  *
  * <p> Example usage: </p>
  *
- * <pre>{@code
- *     Path dir1, dir2, dir3;
- *
+ * {@snippet :
+ *     Path dir1 = ..., dir2 = ..., dir3 = ...;
  *     ModuleFinder finder = ModuleFinder.of(dir1, dir2, dir3);
- *
  *     Optional<ModuleReference> omref = finder.find("jdk.foo");
  *     omref.ifPresent(mref -> ... );
- *
- * }</pre>
+ * }
  *
  * <p> The {@link #find(String) find} and {@link #findAll() findAll} methods
  * defined here can fail for several reasons. These include I/O errors, errors


### PR DESCRIPTION
The specification of the modules API contains several non-normative code examples. We should convert them to use snippets, per [JEP 413](https://openjdk.org/jeps/413).

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291512](https://bugs.openjdk.org/browse/JDK-8291512): Snippetize modules API examples


### Reviewers
 * [Joe Darcy](https://openjdk.org/census#darcy) (@jddarcy - **Reviewer**) ⚠️ Review applies to [22efa8cb](https://git.openjdk.org/jdk19/pull/156/files/22efa8cbe8ba726568283dad74363fad8f65e76d)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/156/head:pull/156` \
`$ git checkout pull/156`

Update a local copy of the PR: \
`$ git checkout pull/156` \
`$ git pull https://git.openjdk.org/jdk19 pull/156/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 156`

View PR using the GUI difftool: \
`$ git pr show -t 156`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/156.diff">https://git.openjdk.org/jdk19/pull/156.diff</a>

</details>
