### PR TITLE
8290562: ThreadMXBean.getThread{Cpu,User}Time fails with -XX:-VMContinuations

### DIFF
--- a/src/hotspot/share/services/management.cpp
+++ b/src/hotspot/share/services/management.cpp
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2003, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2003, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -2169,7 +2169,10 @@ JVM_ENTRY(jlong, jmm_GetThreadCpuTimeWithKind(JNIEnv *env, jlong thread_id, jboo
     ThreadsListHandle tlh;
     java_thread = tlh.list()->find_JavaThread_from_java_tid(thread_id);
     if (java_thread != NULL) {
-      return os::thread_cpu_time((Thread*) java_thread, user_sys_cpu_time != 0);
+      oop thread_obj = java_thread->threadObj();
+      if (thread_obj != NULL && !thread_obj->is_a(vmClasses::BasicVirtualThread_klass())) {
+        return os::thread_cpu_time((Thread*) java_thread, user_sys_cpu_time != 0);
+      }
     }
   }
   return -1;

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -108,7 +108,7 @@ public class VirtualThreads {
     }
 
     /**
-     * Test that ThreadMXBean.getThreadInfo(long) with the thread id of a carrier thread.
+     * Test ThreadMXBean.getThreadInfo(long) with the thread id of a carrier thread.
      * The stack frames of the virtual thread should not be returned.
      */
     @Test

--- a/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
+++ b/test/jdk/java/lang/management/ThreadMXBean/VirtualThreads.java
@@ -23,7 +23,7 @@
 
 /**
  * @test
- * @bug 8284161
+ * @bug 8284161 8290562
  * @summary Test java.lang.management.ThreadMXBean with virtual threads
  * @enablePreview
  * @modules java.base/java.lang:+open java.management
@@ -63,32 +63,56 @@ public class VirtualThreads {
      */
     @Test
     public void testGetAllThreadIds() throws Exception {
-        runInVirtualThread(() -> {
-            long currentTid = Thread.currentThread().getId();
+        Thread vthread = Thread.startVirtualThread(LockSupport::park);
+        try {
             long[] tids = ManagementFactory.getThreadMXBean().getAllThreadIds();
-            boolean found = Arrays.stream(tids).anyMatch(tid -> tid == currentTid);
-            assertFalse(found);
-        });
+
+            // current thread should be included
+            long currentTid = Thread.currentThread().threadId();
+            assertTrue(Arrays.stream(tids).anyMatch(tid -> tid == currentTid));
+
+            // virtual thread should not be included
+            long vtid = vthread.threadId();
+            assertFalse(Arrays.stream(tids).anyMatch(tid -> tid == vtid));
+        } finally {
+            LockSupport.unpark(vthread);
+        }
     }
 
     /**
-     * Test that ThreadMXBean::getThreadInfo returns null for a virual thread.
+     * Test that ThreadMXBean.getThreadInfo(long) returns null for a virtual thread.
      */
     @Test
     public void testGetThreadInfo1() throws Exception {
+        Thread vthread = Thread.startVirtualThread(LockSupport::park);
+        try {
+            long tid = vthread.threadId();
+            ThreadInfo info = ManagementFactory.getThreadMXBean().getThreadInfo(tid);
+            assertTrue(info == null);
+        } finally {
+            LockSupport.unpark(vthread);
+        }
+    }
+
+    /**
+     * Test that ThreadMXBean.getThreadInfo(long) returns null when invoked by a virtual
+     * thread with its own thread id.
+     */
+    @Test
+    public void testGetThreadInfo2() throws Exception {
         runInVirtualThread(() -> {
-            long tid = Thread.currentThread().getId();
+            long tid = Thread.currentThread().threadId();
             ThreadInfo info = ManagementFactory.getThreadMXBean().getThreadInfo(tid);
             assertTrue(info == null);
         });
     }
 
     /**
-     * Test that ThreadMXBean::getThreadInfo on a carrier thread. The stack
-     * frames of the virtual thread should not be returned.
+     * Test that ThreadMXBean.getThreadInfo(long) with the thread id of a carrier thread.
+     * The stack frames of the virtual thread should not be returned.
      */
     @Test
-    public void testGetThreadInfo2() throws Exception {
+    public void testGetThreadInfo3() throws Exception {
         if (!supportsCustomScheduler())
             throw new SkipException("No support for custom schedulers");
         try (ExecutorService pool = Executors.newFixedThreadPool(1)) {
@@ -129,26 +153,77 @@ public class VirtualThreads {
     }
 
     /**
-     * Test that getThreadCpuTime returns -1 for a virual thread..
+     * Test that ThreadMXBean.getThreadInfo(long[]) returns a null ThreadInfo for
+     * elements that correspond to a virtual thread.
      */
     @Test
-    public void testGetThreadCpuTime() throws Exception {
+    public void testGetThreadInfo4() throws Exception {
+        Thread vthread = Thread.startVirtualThread(LockSupport::park);
+        try {
+            long tid0 = Thread.currentThread().threadId();
+            long tid1 = vthread.threadId();
+            long[] tids = new long[] { tid0, tid1 };
+            ThreadInfo[] infos = ManagementFactory.getThreadMXBean().getThreadInfo(tids);
+            assertTrue(infos[0].getThreadId() == tid0);
+            assertTrue(infos[1] == null);
+        } finally {
+            LockSupport.unpark(vthread);
+        }
+    }
+
+    /**
+     * Test that ThreadMXBean.getThreadCpuTime(long) returns -1 for a virtual thread.
+     */
+    @Test
+    public void testGetThreadCpuTime1() {
+        Thread vthread = Thread.startVirtualThread(LockSupport::park);
+        try {
+            long tid = vthread.threadId();
+            long cpuTime = ManagementFactory.getThreadMXBean().getThreadCpuTime(tid);
+            assertTrue(cpuTime == -1L);
+        } finally {
+            LockSupport.unpark(vthread);
+        }
+    }
+
+    /**
+     * Test that ThreadMXBean.getThreadCpuTime(long) returns -1 when invoked by a
+     * virtual thread with its own thread id.
+     */
+    @Test
+    public void testGetThreadCpuTime2() throws Exception {
         runInVirtualThread(() -> {
-            long tid = Thread.currentThread().getId();
+            long tid = Thread.currentThread().threadId();
             long cpuTime = ManagementFactory.getThreadMXBean().getThreadCpuTime(tid);
             assertTrue(cpuTime == -1L);
         });
     }
 
     /**
-     * Test that getThreadUserTime returns -1 for a virual thread.
+     * Test that ThreadMXBean.getThreadUserTime(long) returns -1 for a virtual thread.
      */
     @Test
-    public void testGetThreadUserTime() throws Exception {
+    public void testGetThreadUserTime1() {
+        Thread vthread = Thread.startVirtualThread(LockSupport::park);
+        try {
+            long tid = vthread.threadId();
+            long userTime = ManagementFactory.getThreadMXBean().getThreadUserTime(tid);
+            assertTrue(userTime == -1L);
+        } finally {
+            LockSupport.unpark(vthread);
+        }
+    }
+
+    /**
+     * Test that ThreadMXBean.getThreadUserTime(long) returns -1 when invoked by a
+     * virtual thread with its own thread id.
+     */
+    @Test
+    public void testGetThreadUserTime2() throws Exception {
         runInVirtualThread(() -> {
-            long tid = Thread.currentThread().getId();
-            long cpuTime = ManagementFactory.getThreadMXBean().getThreadUserTime(tid);
-            assertTrue(cpuTime == -1L);
+            long tid = Thread.currentThread().threadId();
+            long userTime = ManagementFactory.getThreadMXBean().getThreadUserTime(tid);
+            assertTrue(userTime == -1L);
         });
     }
 


### PR DESCRIPTION
ThreadMXBean.getThread{Cpu,User}Time is specified to return -1L when invoked with the id of a virtual thread. This isn't so when running with -XX:-VMContinuations (or ports without support for continuations in the VM) as it returns the cpu/user time of the OS thread that that the virtual thread is bound. A small oversight with JDK-8287496, and missed because our unit test only exercises these methods with the id of the "current virtual thread". The code path when the called with the id that is not the current thread is a different code path.

The change is limited to jmm_GetThreadCpuTimeWithKind.  I didn't change jmm_GetThreadCpuTimesWithKind because it seems to be unused/dead code. I'll create a separate issue to look at that (it doesn't need to be removed/changed for JDK 19).

The test case for this API is expanded to cover more cases where the current thread is special cased in the implementation.

JDK 19 is in RDP2 so this change will require additional approval.

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8290562](https://bugs.openjdk.org/browse/JDK-8290562): ThreadMXBean.getThread{Cpu,User}Time fails with -XX:-VMContinuations


### Reviewers
 * [Serguei Spitsyn](https://openjdk.org/census#sspitsyn) (@sspitsyn - **Reviewer**)
 * [Kevin Walls](https://openjdk.org/census#kevinw) (@kevinjwalls - Committer) ⚠️ Review applies to [4c834d39](https://git.openjdk.org/jdk19/pull/157/files/4c834d39e65337a5284b9a7e8aea3a337f2fcb0d)
 * [Mandy Chung](https://openjdk.org/census#mchung) (@mlchung - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/157/head:pull/157` \
`$ git checkout pull/157`

Update a local copy of the PR: \
`$ git checkout pull/157` \
`$ git pull https://git.openjdk.org/jdk19 pull/157/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 157`

View PR using the GUI difftool: \
`$ git pr show -t 157`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/157.diff">https://git.openjdk.org/jdk19/pull/157.diff</a>

</details>
