### PR TITLE
8291524: jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java Value not equal to 2, field='hiddenClassCount', value='0'

### DIFF
--- a/test/jdk/jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2014, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2014, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -56,9 +56,11 @@ public class TestClassLoaderStatsEvent {
     private final static String CLASS_LOADER_NAME = "MyDummyClassLoader";
     private final static String CLASSLOADER_TYPE_NAME = "jdk.jfr.event.runtime.TestClassLoaderStatsEvent$DummyClassLoader";
     public static DummyClassLoader dummyloader;
+    public static Class<?>[] classes;
 
     public static void main(String[] args) throws Throwable {
         createDummyClassLoader(CLASS_LOADER_NAME);
+        System.gc();
 
         Recording recording = new Recording();
         recording.enable(EVENT_NAME);
@@ -106,7 +108,7 @@ public class TestClassLoaderStatsEvent {
 
         Method m = c.getDeclaredMethod("createNonFindableClasses", byte[].class);
         m.setAccessible(true);
-        m.invoke(null, klassbuf);
+        classes = (Class[]) m.invoke(null, klassbuf);
     }
 
     public static class DummyClassLoader extends ClassLoader {

--- a/test/jdk/jdk/jfr/event/runtime/TestClasses.java
+++ b/test/jdk/jdk/jfr/event/runtime/TestClasses.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (c) 2013, 2021, Oracle and/or its affiliates. All rights reserved.
+ * Copyright (c) 2013, 2022, Oracle and/or its affiliates. All rights reserved.
  * DO NOT ALTER OR REMOVE COPYRIGHT NOTICES OR THIS FILE HEADER.
  *
  * This code is free software; you can redistribute it and/or modify it
@@ -85,10 +85,12 @@ class TestClass {
         r.run();
     }
 
-    public static void createNonFindableClasses(byte[] klassbuf) throws Throwable {
+    public static Class<?>[] createNonFindableClasses(byte[] klassbuf) throws Throwable {
         // Create a hidden class and an array of hidden classes.
         Lookup lookup = MethodHandles.lookup();
-        Class<?> clh = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
-        Class<?> arrayOfHidden = Array.newInstance(clh, 10).getClass(); // HAS ISSUES?
+        Class<?>[] classes = new Class[2];
+        classes[0] = lookup.defineHiddenClass(klassbuf, false, NESTMATE).lookupClass();
+        classes[1] = Array.newInstance(classes[0], 10).getClass(); // HAS ISSUES?
+        return classes;
     }
 }


### PR DESCRIPTION
Could I have a review of change that fixes an intermittent test failure. The classes are garbage collected before they are being recorded by JFR. The fix is to add a hard reference to them. I also added a call to System.gc() to ensure the test is not sensitive to garbage collections.

Testing: test/jdk/jdk/jfr/ + 100 times test/jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java 

Thanks
Erik

<!-- Anything below this marker will be automatically updated, please do not edit manually! -->
---------
### Progress
- [x] Change must be properly reviewed (1 review required, with at least 1 [Reviewer](https://openjdk.org/bylaws#reviewer))
- [x] Change must not contain extraneous whitespace
- [x] Commit message must refer to an issue

### Issue
 * [JDK-8291524](https://bugs.openjdk.org/browse/JDK-8291524): jdk/jfr/event/runtime/TestClassLoaderStatsEvent.java Value not equal to 2, field='hiddenClassCount', value='0'


### Reviewers
 * [Harold Seigel](https://openjdk.org/census#hseigel) (@hseigel - **Reviewer**)


### Reviewing
<details><summary>Using <code>git</code></summary>

Checkout this PR locally: \
`$ git fetch https://git.openjdk.org/jdk19 pull/158/head:pull/158` \
`$ git checkout pull/158`

Update a local copy of the PR: \
`$ git checkout pull/158` \
`$ git pull https://git.openjdk.org/jdk19 pull/158/head`

</details>
<details><summary>Using Skara CLI tools</summary>

Checkout this PR locally: \
`$ git pr checkout 158`

View PR using the GUI difftool: \
`$ git pr show -t 158`

</details>
<details><summary>Using diff file</summary>

Download this PR as a diff file: \
<a href="https://git.openjdk.org/jdk19/pull/158.diff">https://git.openjdk.org/jdk19/pull/158.diff</a>

</details>
